### PR TITLE
fix: pass explicit path to eza to prevent stdin blocking

### DIFF
--- a/src/kon/tools/bash.py
+++ b/src/kon/tools/bash.py
@@ -71,7 +71,11 @@ def _transform_command(command: str) -> str:
 
     # Replace 'ls' with 'eza --git-ignore', preserving any following arguments
     # We only match 'ls' as a word (not part of another command)
-    return re.sub(r"\bls\b", "eza --git-ignore", command, count=1)
+    result = re.sub(r"\bls\b", "eza --git-ignore", command, count=1)
+    # eza blocks on stdin in subprocess envs when no path arg is given
+    if all(a.startswith("-") for a in stripped.split()[1:]):
+        result += " ."
+    return result
 
 
 class TruncationResult:


### PR DESCRIPTION
## Summary

`ls` silently returns no output through the bash tool because `_transform_command` rewrites it to `eza --git-ignore`, and eza reads from stdin when no path argument is given. Since the bash tool sets `stdin=DEVNULL`, eza gets immediate EOF and exits with nothing. This doesn't happen in a terminal because stdin is a TTY, which eza detects and skips.

## Fix

Append `.` when the transformed command has no path argument, so eza always gets an explicit directory to list.