### PR TITLE
Fix/OpenAI login stdin leak

### DIFF
--- a/src/kon/llm/oauth/openai.py
+++ b/src/kon/llm/oauth/openai.py
@@ -327,6 +327,12 @@ async def login(
         if on_manual_input:
             manual_task = asyncio.create_task(on_manual_input())
 
+        if not callback_awaitable and not manual_task:
+            raise RuntimeError(
+                "OpenAI OAuth failed: could not start callback server on port 1455 "
+                "and no manual input handler provided."
+            )
+
         if callback_awaitable and manual_task:
             done, pending = await asyncio.wait(
                 {callback_awaitable, manual_task}, return_when=asyncio.FIRST_COMPLETED, timeout=300
@@ -355,8 +361,7 @@ async def login(
 
         if not code:
             raise TimeoutError(
-                "OpenAI OAuth timed out waiting for authorization. "
-                "If callback didn't work, retry and paste the full callback URL when prompted."
+                "OpenAI OAuth timed out waiting for authorization callback on port 1455."
             )
 
         creds = await _exchange_code_for_tokens(code, verifier)

--- a/src/kon/tools_manager.py
+++ b/src/kon/tools_manager.py
@@ -146,6 +146,12 @@ def _extract_binary(archive_path: Path, binary_name: str, dest: Path) -> Path:
                 tar.extractall(tmp, filter="data")
         elif str(archive_path).endswith(".zip"):
             with zipfile.ZipFile(archive_path) as zf:
+                resolved_tmp = tmp.resolve()
+                for info in zf.infolist():
+                    if not (tmp / info.filename).resolve().is_relative_to(resolved_tmp):
+                        raise ValueError(
+                            f"Zip entry escapes target directory: {info.filename}"
+                        )
                 zf.extractall(tmp)
 
         # Search for the binary: could be at top level or in a subdirectory

--- a/src/kon/ui/commands.py
+++ b/src/kon/ui/commands.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -609,14 +608,8 @@ Keybindings:
                 "Waiting for authorization callback on http://localhost:1455/auth/callback ...",
             )
 
-        async def on_manual_input() -> str:
-            loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(
-                None, input, "Paste OpenAI callback URL (or just code): "
-            )
-
         try:
-            await openai_login(on_auth_url=on_auth_url, on_manual_input=on_manual_input)
+            await openai_login(on_auth_url=on_auth_url)
             chat.add_info_message(
                 "Successfully logged in to OpenAI!\n"
                 "You can now use /model to select openai-codex models."

--- a/tests/llm/test_openai_oauth.py
+++ b/tests/llm/test_openai_oauth.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+import pytest
+
+from kon.llm.oauth.openai import login
+
+
+@pytest.mark.asyncio
+async def test_login_raises_runtime_error_when_server_fails_and_no_manual_input():
+    with (
+        patch("kon.llm.oauth.openai._start_callback_server", side_effect=OSError("port in use")),
+        pytest.raises(RuntimeError, match="could not start callback server"),
+    ):
+        await login(on_auth_url=None, on_manual_input=None)

--- a/tests/test_tools_manager.py
+++ b/tests/test_tools_manager.py
@@ -1,0 +1,18 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from kon.tools_manager import _extract_binary
+
+
+def test_extract_binary_rejects_zip_path_traversal(tmp_path: Path):
+    archive = tmp_path / "malicious.zip"
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("../../evil.txt", "pwned")
+
+    with pytest.raises(ValueError, match="escapes target directory"):
+        _extract_binary(archive, "evil.txt", dest)


### PR DESCRIPTION
## Summary

After `/login` > OpenAI, the TUI becomes laggy with delayed and missed keystrokes, in which restarting is the only way to fix the issues.

The login flow passes a manual input callback that spawns a thread blocking on stdin, and when the browser OAuth callback completes first, the asyncio task is cancelled but the thread can't be killed. It stays blocked on the same fd that Textual's input thread reads from, and the two competing for stdin causes the dropped keystrokes.

```python
# Ex: survives cancellation, races with Textual for stdin
async def on_manual_input() -> str:
    loop = asyncio.get_running_loop()
    return await loop.run_in_executor(
        None, input, "Paste OpenAI callback URL (or just code): "
    )
```

I removed this callback from the TUI caller since `login()` already works without it. I also added a guard for when the localhost callback server fails to bind, so it raises immediately instead of waiting 5 minutes for a misleading timeout.

Separately, I added path traversal validation to zip extraction in the tool downloader, matching the tarfile protection from #14.