### PR TITLE
feat: add configurable request timeout for API calls

### DIFF
--- a/src/kon/config.py
+++ b/src/kon/config.py
@@ -76,6 +76,7 @@ class LLMConfig(BaseModel):
     default_thinking_level: str
     system_prompt: SystemPromptConfig
     tool_call_idle_timeout_seconds: float = 180
+    request_timeout_seconds: float = 600
     auth: AuthConfig = AuthConfig()
 
 

--- a/src/kon/defaults/config.toml
+++ b/src/kon/defaults/config.toml
@@ -11,6 +11,9 @@ default_thinking_level = "high"
 # Abort a tool call if it stays idle for this long during a turn.
 # Helps prevent stalled tool executions from hanging the agent loop.
 tool_call_idle_timeout_seconds = 180
+# HTTP request timeout for LLM API calls (in seconds).
+# Local models (e.g. llama.cpp) may need a higher value for long compaction requests.
+request_timeout_seconds = 600
 
 [llm.auth]
 # Auth policy for OpenAI-compatible and Anthropic-compatible endpoints.

--- a/src/kon/llm/providers/openai_completions.py
+++ b/src/kon/llm/providers/openai_completions.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
+from kon import config as kon_config
 from openai import APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat import (
     ChatCompletionChunk,
@@ -99,7 +100,11 @@ class OpenAICompletionsProvider(BaseProvider):
                 "Set OPENAI_API_KEY or ZAI_API_KEY environment variable, "
                 'or configure llm.auth.openai_compat = "auto"/"none" for local endpoints.'
             )
-        self._client = AsyncOpenAI(api_key=api_key, base_url=config.base_url)
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=config.base_url,
+            timeout=kon_config.llm.request_timeout_seconds,
+        )
         self._compat = _detect_compat(
             config.provider or "", config.base_url or "", config.model or ""
         )

--- a/src/kon/llm/providers/openai_responses.py
+++ b/src/kon/llm/providers/openai_responses.py
@@ -2,6 +2,7 @@ import json
 from collections.abc import AsyncIterator
 from typing import Any
 
+from kon import config as kon_config
 from openai import APIStatusError, AsyncOpenAI, RateLimitError
 
 from ...core.types import (
@@ -51,6 +52,7 @@ class OpenAIResponsesProvider(BaseProvider):
                 api_key=self.config.api_key,
                 base_url=self.config.base_url,
                 default_headers=self._headers,
+                timeout=kon_config.llm.request_timeout_seconds,
             )
         return self._client
 


### PR DESCRIPTION
Add configurable HTTP request timeout for OpenAI API calls via a `[llm] request_timeout_seconds` config option

The default OpenAI SDK's timeout is 600 s. When running on a local llama.cpp backend, long-running requests like context compaction could exceed this and fail with `Compaction failed: Request timed out` with no way to bump the limit.

In order not to run into any timeouts also set the `--timeout N` flag on lama.cpp's side.