### PR TITLE
convert LaTeX to Unicode before rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ select = [
     "RUF", # ruff-specific rules
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"src/kon/ui/latex.py" = ["RUF001"]
+"tests/ui/test_latex.py" = ["RUF001"]
+
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false
 

--- a/src/kon/ui/formatting.py
+++ b/src/kon/ui/formatting.py
@@ -13,6 +13,8 @@ from rich.theme import Theme
 
 from kon import config
 
+from .latex import preprocess_latex
+
 _MARKDOWN_THEME: Theme | None = None
 
 
@@ -143,6 +145,7 @@ def strip_markdown_for_collapsed_text(text: str) -> str:
 
 
 def format_markdown(text: str, width: int | None = None) -> Text:
+    text = preprocess_latex(text)
     sanitized = _strip_inline_code_ticks_in_headings(text)
     md = CustomMarkdown(sanitized)
     if width is None:

--- a/src/kon/ui/latex.py
+++ b/src/kon/ui/latex.py
@@ -1,0 +1,352 @@
+"""LaTeX math-to-Unicode converter.
+
+Adapted from innomd by Innomatica GmbH (MIT License).
+Source: https://github.com/Innomatica-GmbH/innomd
+Commit: 35021c740a44d197cae4e8c0ab142e0b5e0cdaec
+"""
+
+import re
+
+GREEK = {
+    r"\alpha": "α",
+    r"\beta": "β",
+    r"\gamma": "γ",
+    r"\delta": "δ",
+    r"\epsilon": "ε",
+    r"\varepsilon": "ε",
+    r"\zeta": "ζ",
+    r"\eta": "η",
+    r"\theta": "θ",
+    r"\vartheta": "ϑ",
+    r"\iota": "ι",
+    r"\kappa": "κ",
+    r"\lambda": "λ",
+    r"\mu": "μ",
+    r"\nu": "ν",
+    r"\xi": "ξ",
+    r"\pi": "π",
+    r"\varpi": "ϖ",
+    r"\rho": "ρ",
+    r"\varrho": "ϱ",
+    r"\sigma": "σ",
+    r"\varsigma": "ς",
+    r"\tau": "τ",
+    r"\upsilon": "υ",
+    r"\phi": "φ",
+    r"\varphi": "ϕ",
+    r"\chi": "χ",
+    r"\psi": "ψ",
+    r"\omega": "ω",
+    r"\Gamma": "Γ",
+    r"\Delta": "Δ",
+    r"\Theta": "Θ",
+    r"\Lambda": "Λ",
+    r"\Xi": "Ξ",
+    r"\Pi": "Π",
+    r"\Sigma": "Σ",
+    r"\Upsilon": "Υ",
+    r"\Phi": "Φ",
+    r"\Psi": "Ψ",
+    r"\Omega": "Ω",
+    r"\hbar": "ℏ",
+    r"\ell": "ℓ",
+    r"\Re": "ℜ",
+    r"\Im": "ℑ",
+}
+
+OPERATORS = {
+    r"\cdot": "·",
+    r"\times": "×",
+    r"\div": "÷",
+    r"\pm": "±",
+    r"\mp": "∓",
+    r"\ast": "∗",
+    r"\star": "⋆",
+    r"\circ": "∘",
+    r"\bullet": "•",
+    r"\leq": "≤",
+    r"\le": "≤",
+    r"\geq": "≥",
+    r"\ge": "≥",
+    r"\neq": "≠",
+    r"\ne": "≠",
+    r"\approx": "≈",
+    r"\equiv": "≡",
+    r"\sim": "∼",
+    r"\simeq": "≃",
+    r"\cong": "≅",
+    r"\propto": "∝",
+    r"\ll": "≪",
+    r"\gg": "≫",
+    r"\infty": "∞",
+    r"\partial": "∂",
+    r"\nabla": "∇",
+    r"\prime": "′",
+    r"\sum": "∑",
+    r"\prod": "∏",
+    r"\coprod": "∐",
+    r"\int": "∫",
+    r"\iint": "∬",
+    r"\iiint": "∭",
+    r"\oint": "∮",
+    r"\sqrt": "√",
+    r"\rightarrow": "→",
+    r"\to": "→",
+    r"\leftarrow": "←",
+    r"\gets": "←",
+    r"\Rightarrow": "⇒",
+    r"\Leftarrow": "⇐",
+    r"\Leftrightarrow": "⇔",
+    r"\leftrightarrow": "↔",
+    r"\uparrow": "↑",
+    r"\downarrow": "↓",
+    r"\mapsto": "↦",
+    r"\longrightarrow": "⟶",
+    r"\longleftarrow": "⟵",
+    r"\in": "∈",
+    r"\notin": "∉",
+    r"\ni": "∋",
+    r"\subset": "⊂",
+    r"\supset": "⊃",
+    r"\subseteq": "⊆",
+    r"\supseteq": "⊇",
+    r"\cup": "∪",
+    r"\cap": "∩",
+    r"\setminus": "∖",
+    r"\emptyset": "∅",
+    r"\varnothing": "∅",
+    r"\forall": "∀",
+    r"\exists": "∃",
+    r"\nexists": "∄",
+    r"\neg": "¬",
+    r"\land": "∧",
+    r"\wedge": "∧",
+    r"\lor": "∨",
+    r"\vee": "∨",
+    r"\therefore": "∴",
+    r"\because": "∵",
+    r"\ldots": "…",
+    r"\cdots": "⋯",
+    r"\vdots": "⋮",
+    r"\ddots": "⋱",
+    r"\dots": "…",
+    r"\quad": " ",
+    r"\qquad": " ",
+    r"\,": " ",
+    r"\;": " ",
+    r"\:": " ",
+    r"\!": "",
+    r"\ ": " ",
+    r"\%": "%",
+    r"\$": "$",
+    r"\&": "&",
+    r"\#": "#",
+    r"\_": "_",
+    r"\{": "{",
+    r"\}": "}",
+    r"\deg": "°",
+    r"\degree": "°",
+    r"\langle": "⟨",
+    r"\rangle": "⟩",
+    r"\lfloor": "⌊",
+    r"\rfloor": "⌋",
+    r"\lceil": "⌈",
+    r"\rceil": "⌉",
+    r"\aleph": "ℵ",
+    r"\Box": "□",
+    r"\Diamond": "◇",
+    r"\triangle": "△",
+    r"\mathbb{R}": "ℝ",
+    r"\mathbb{N}": "ℕ",
+    r"\mathbb{Z}": "ℤ",
+    r"\mathbb{Q}": "ℚ",
+    r"\mathbb{C}": "ℂ",
+    r"\mathbb{P}": "ℙ",
+    r"\mathcal{L}": "ℒ",
+    r"\mathcal{H}": "ℋ",
+    r"\left": "",
+    r"\right": "",
+    r"\bigl": "",
+    r"\bigr": "",
+    r"\big": "",
+    r"\Big": "",
+    r"\Bigg": "",
+    r"\displaystyle": "",
+    r"\textstyle": "",
+    r"\scriptstyle": "",
+}
+
+SUPERSCRIPT = str.maketrans(
+    "0123456789+-=()nabcdefghijklmoprstuvwxyzABDEGHIJKLMNOPRTUVW",
+    "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ⁿᵃᵇᶜᵈᵉᶠᵍʰᵢʲᵏˡᵐᵒʳˢᵗᵘᵛʷʸᵚᵜᵝᵞᵟᴬᴮᴰᴱᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾᴿᵀᵁ",
+)
+SUBSCRIPT = str.maketrans("0123456789+-=()aehijklmnoprstuvx", "₀₁₂₃₄₅₆₇₈₉₊₋₌₍₎ₐₑₕᵢⱼₖₗₘₙₒₚᵣₛₜᵤᵥₓ")
+
+
+def _to_super(s: str) -> str:
+    if s and all(c in "0123456789+-=()nabcdefghijklmoprstuvwxyzABDEGHIJKLMNOPRTUVW" for c in s):
+        return s.translate(SUPERSCRIPT)
+    if len(s) == 1:
+        return "^" + s
+    return "^(" + s + ")"
+
+
+def _to_sub(s: str) -> str:
+    if s and all(c in "0123456789+-=()aehijklmnoprstuvx" for c in s):
+        return s.translate(SUBSCRIPT)
+    if len(s) == 1:
+        return "_" + s
+    return "_(" + s + ")"
+
+
+def _balanced_groups(s: str, start: int) -> tuple[str, int] | None:
+    if start >= len(s) or s[start] != "{":
+        return None
+    depth = 0
+    for i in range(start, len(s)):
+        if s[i] == "{":
+            depth += 1
+        elif s[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return s[start + 1 : i], i + 1
+    return None
+
+
+def _replace_command_with_groups(text: str, name: str, n_args: int, fn) -> str:
+    out = []
+    i = 0
+    pattern = "\\" + name
+    while i < len(text):
+        if text.startswith(pattern, i):
+            after = i + len(pattern)
+            if after < len(text) and text[after].isalpha():
+                out.append(text[i])
+                i += 1
+                continue
+            args = []
+            j = after
+            while j < len(text) and text[j] == " ":
+                j += 1
+            ok = True
+            for _ in range(n_args):
+                grp = _balanced_groups(text, j)
+                if grp is None:
+                    ok = False
+                    break
+                args.append(grp[0])
+                j = grp[1]
+            if ok:
+                out.append(fn(args))
+                i = j
+                continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def _convert_math(tex: str) -> str:
+    s = tex
+    for _ in range(3):
+        for cmd in (
+            "text",
+            "mathrm",
+            "mathbf",
+            "mathit",
+            "mathsf",
+            "mathtt",
+            "operatorname",
+            "textbf",
+            "textit",
+        ):
+            s = _replace_command_with_groups(s, cmd, 1, lambda a: a[0])
+    for _ in range(4):
+        s = _replace_command_with_groups(
+            s,
+            "frac",
+            2,
+            lambda a: (
+                f"({a[0]})/({a[1]})"
+                if any(c in a[0] + a[1] for c in "+-**·× ")
+                else f"{a[0]}/{a[1]}"
+            ),
+        )
+        s = _replace_command_with_groups(
+            s,
+            "dfrac",
+            2,
+            lambda a: (
+                f"({a[0]})/({a[1]})"
+                if any(c in a[0] + a[1] for c in "+-**·× ")
+                else f"{a[0]}/{a[1]}"
+            ),
+        )
+        s = _replace_command_with_groups(
+            s,
+            "tfrac",
+            2,
+            lambda a: (
+                f"({a[0]})/({a[1]})"
+                if any(c in a[0] + a[1] for c in "+-**·× ")
+                else f"{a[0]}/{a[1]}"
+            ),
+        )
+    s = re.sub(
+        r"\\sqrt\[([^\]]+)\]\{([^{}]+)\}",
+        lambda m: _to_super(m.group(1)) + "√(" + m.group(2) + ")",
+        s,
+    )
+    s = _replace_command_with_groups(s, "sqrt", 1, lambda a: "√(" + a[0] + ")")
+    s = _replace_command_with_groups(s, "vec", 1, lambda a: a[0] + "⃗")
+    s = _replace_command_with_groups(s, "hat", 1, lambda a: a[0] + "̂")
+    s = _replace_command_with_groups(s, "bar", 1, lambda a: a[0] + "̄")
+    s = _replace_command_with_groups(s, "dot", 1, lambda a: a[0] + "̇")
+    items = sorted(list(GREEK.items()) + list(OPERATORS.items()), key=lambda x: -len(x[0]))
+    for k, v in items:
+        if k and k[-1].isalpha():
+            s = re.sub(re.escape(k) + r"(?![A-Za-z])", v, s)
+        else:
+            s = s.replace(k, v)
+    s = re.sub(r"\^\{([^{}]+)\}", lambda m: _to_super(m.group(1)), s)
+    s = re.sub(r"_\{([^{}]+)\}", lambda m: _to_sub(m.group(1)), s)
+    s = re.sub(r"\^(\\?[A-Za-z0-9+\-])", lambda m: _to_super(m.group(1).lstrip("\\")), s)
+    s = re.sub(r"_(\\?[A-Za-z0-9+\-])", lambda m: _to_sub(m.group(1).lstrip("\\")), s)
+    prev = None
+    while prev != s:
+        prev = s
+        s = re.sub(r"\{([^{}]*)\}", r"\1", s)
+    s = re.sub(r"[ \t]+", " ", s).strip()
+    return s
+
+
+_FENCE_RE = re.compile(r"(^```.*?^```)", re.DOTALL | re.MULTILINE)
+
+
+def preprocess_latex(text: str) -> str:
+    r"""Convert LaTeX math delimiters in *text* to Unicode, leaving code fences untouched.
+
+    Handles inline ``$...$``, ``\(...\)``, display ``$$...$$``, and ``\[...\]``.
+    Math inside fenced code blocks (`` ``` ``) is preserved verbatim.
+    """
+    parts = _FENCE_RE.split(text)
+    out = []
+    for part in parts:
+        if part.startswith("```"):
+            out.append(part)
+            continue
+        part = re.sub(
+            r"\$\$(.+?)\$\$",
+            lambda m: "\n\n" + _convert_math(m.group(1)) + "\n\n",
+            part,
+            flags=re.DOTALL,
+        )
+        part = re.sub(
+            r"\\\[(.+?)\\\]",
+            lambda m: "\n\n" + _convert_math(m.group(1)) + "\n\n",
+            part,
+            flags=re.DOTALL,
+        )
+        part = re.sub(r"(?<!\$)\$(.+?)\$(?!\$)", lambda m: _convert_math(m.group(1)), part)
+        part = re.sub(r"\\\((.+?)\\\)", lambda m: _convert_math(m.group(1)), part)
+        out.append(part)
+    return "".join(out)

--- a/tests/ui/test_latex.py
+++ b/tests/ui/test_latex.py
@@ -1,0 +1,60 @@
+from kon.ui.latex import preprocess_latex
+
+
+def test_inline_dollar_math():
+    text = "Energy is $E = mc^2$ and that's it."
+    result = preprocess_latex(text)
+    assert "E = mc²" in result
+    assert "$" not in result
+
+
+def test_display_double_dollar_math():
+    text = "Here is an equation:\n$$\\lambda = \\frac{b}{T}$$\nDone."
+    result = preprocess_latex(text)
+    assert "λ = b/T" in result
+    assert "$$" not in result
+    assert ">" not in result
+
+
+def test_latex_in_code_fence_preserved():
+    text = "```\n$E = mc^2$\n```"
+    result = preprocess_latex(text)
+    assert "$E = mc^2$" in result
+
+
+def test_greek_letters():
+    text = r"$\alpha + \beta = \gamma$"
+    result = preprocess_latex(text)
+    assert "α + β = γ" in result
+
+
+def test_fractions():
+    text = r"$\frac{a+b}{c}$"
+    result = preprocess_latex(text)
+    assert "(a+b)/(c)" in result
+
+
+def test_sqrt():
+    text = r"$\sqrt{x}$"
+    result = preprocess_latex(text)
+    assert "√(x)" in result
+
+
+def test_no_math_unchanged():
+    text = "Just plain text with $5 dollars."
+    result = preprocess_latex(text)
+    assert result == text
+
+
+def test_backslash_bracket_display():
+    text = r"\[\sum_{i=0}^{n} x_i\]"
+    result = preprocess_latex(text)
+    assert "∑" in result
+    assert r"\[" not in result
+
+
+def test_backslash_paren_inline():
+    text = r"\(\\alpha\\)"
+    result = preprocess_latex(text)
+    assert "α" in result
+    assert r"\(" not in result


### PR DESCRIPTION
Neat agent! I decided to try it on a toy project based on the _Nature of Code_ book, and the LLM chat about the task included a bunch of LaTeX, which didn't look great initially. So I took a little side-quest to add it to Kon.

Code generated by Kon + Kimi 2.6 (via OpenRouter) with light guidance from me.

The core conversion code was swiped from https://github.com/Innomatica-GmbH/innomd

One remaining annoyance I've noticed is that standard function names still have the leading slash, e.g. `\sin(x)`. Perhaps it's better to replace that slash with a space. AFAICS the innomd implementation doesn't do anything special here.

Thanks for your consideration.

Example output:
<img width="1441" height="1160" alt="image" src="https://github.com/user-attachments/assets/6515df95-ecd1-4d9f-a3db-750bd2f32756" />