### PR TITLE
Feat: Add /permissions command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Type `/` at the start of the input box to see available commands.
 | `/compact` | Compact the current conversation immediately |
 | `/handoff` | Create a focused handoff into a new session |
 | `/themes` | Switch UI themes |
+| `/permissions` | Switch permission mode (prompt/auto) |
 | `/export` | Export current session to standalone HTML |
 | `/copy` | Copy the last assistant response to the clipboard |
 | `/login` | Authenticate with a supported OAuth provider |
@@ -462,6 +463,8 @@ Kon supports two permission modes:
 | `auto` | Skip approval prompts |
 
 In `prompt` mode, non-mutating tools are allowed automatically, and some clearly read-only shell commands are also allowed.
+
+Use `/permissions` to switch modes interactively, or set in config:
 
 ```toml
 [permissions]

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -595,6 +595,8 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
                     self._select_model(item.value)
                 case SelectionMode.THEME:
                     self._select_theme(item.value)
+                case SelectionMode.PERMISSIONS:
+                    self._select_permission_mode(item.value)
                 case SelectionMode.LOGIN:
                     self._select_login_provider(item.value)
                 case SelectionMode.LOGOUT:

--- a/src/kon/ui/autocomplete.py
+++ b/src/kon/ui/autocomplete.py
@@ -364,6 +364,7 @@ DEFAULT_COMMANDS = [
     SlashCommand("clear", "Clear conversation history"),
     SlashCommand("model", "Change model"),
     SlashCommand("themes", "Change UI theme"),
+    SlashCommand("permissions", "Change permission mode"),
     SlashCommand("new", "Start new conversation"),
     SlashCommand("handoff", "Start focused handoff in new session", submit_on_select=False),
     SlashCommand("resume", "Resume a session"),

--- a/src/kon/ui/commands.py
+++ b/src/kon/ui/commands.py
@@ -93,6 +93,9 @@ class CommandsMixin:
         if cmd == "themes":
             self._handle_themes_command(args)
             return True
+        if cmd == "permissions":
+            self._handle_permissions_command(args)
+            return True
         if cmd == "handoff":
             self._handle_handoff_command(args)
             return True
@@ -129,6 +132,7 @@ class CommandsMixin:
   /compact   - Compact current conversation now
   /model     - Change model (/model gpt-4o)
   /themes    - Change UI theme (/themes gruvbox-dark)
+  /permissions - Change permission mode (/permissions auto)
   /new       - Start new conversation
   /handoff   - Start focused handoff in new session
   /resume    - Resume a session
@@ -219,6 +223,50 @@ Extra tools:
         input_box.set_completing(True)
         input_box.focus()
         self._selection_mode = SelectionMode.THEME
+
+    def _handle_permissions_command(self, args: str) -> None:
+        chat = self.query_one("#chat-log", ChatLog)
+
+        requested = args.strip()
+        if requested:
+            if requested in ("prompt", "auto"):
+                self._select_permission_mode(requested)
+            else:
+                chat.add_info_message(f"Invalid permission mode: {requested}. Use 'prompt' or 'auto'", error=True)
+            return
+
+        current_mode = config.permissions.mode
+        items = [
+            ListItem(
+                value="prompt",
+                label="Prompt",
+                description="prompt ✓" if current_mode == "prompt" else "prompt",
+            ),
+            ListItem(
+                value="auto",
+                label="Auto",
+                description="auto ✓" if current_mode == "auto" else "auto",
+            ),
+        ]
+
+        completion_list = self.query_one("#completion-list", FloatingList)
+        completion_list.show(items, searchable=True)
+
+        input_box = self.query_one("#input-box", InputBox)
+        input_box.clear()
+        input_box.set_autocomplete_enabled(False)
+        input_box.set_completing(True)
+        input_box.focus()
+        self._selection_mode = SelectionMode.PERMISSIONS
+
+    def _select_permission_mode(self, mode: str) -> None:
+        from kon.config import get_config
+        
+        current_config = get_config()
+        current_config._parsed.permissions.mode = mode
+        
+        chat = self.query_one("#chat-log", ChatLog)
+        chat.add_info_message(f"Permission mode changed to {mode}")
 
     def _select_theme(self, theme_id: str) -> None:
         set_theme(theme_id)

--- a/src/kon/ui/selection_mode.py
+++ b/src/kon/ui/selection_mode.py
@@ -7,3 +7,4 @@ class SelectionMode(StrEnum):
     THEME = "theme"
     LOGIN = "login"
     LOGOUT = "logout"
+    PERMISSIONS = "permissions"

--- a/tests/ui/test_permissions_command.py
+++ b/tests/ui/test_permissions_command.py
@@ -1,0 +1,39 @@
+"""Test the /permissions slash command functionality."""
+
+from kon.ui.autocomplete import DEFAULT_COMMANDS, SlashCommand
+from kon.ui.selection_mode import SelectionMode
+from kon.ui.commands import CommandsMixin
+
+
+def test_permissions_command_in_default_commands():
+    """Test that the permissions command is in the default commands list."""
+    permissions_cmd = None
+    for cmd in DEFAULT_COMMANDS:
+        if cmd.name == "permissions":
+            permissions_cmd = cmd
+            break
+    
+    assert permissions_cmd is not None, "Permissions command not found in DEFAULT_COMMANDS"
+    assert permissions_cmd.description == "Change permission mode"
+    assert isinstance(permissions_cmd, SlashCommand)
+
+
+def test_permissions_selection_mode():
+    """Test that PERMISSIONS selection mode exists."""
+    assert hasattr(SelectionMode, "PERMISSIONS")
+    assert SelectionMode.PERMISSIONS == "permissions"
+
+
+def test_permissions_command_handler_exists():
+    """Test that the permission command handler methods exist."""
+    assert hasattr(CommandsMixin, "_handle_permissions_command")
+    assert hasattr(CommandsMixin, "_select_permission_mode")
+
+
+def test_permissions_command_in_help():
+    """Test that permissions command is mentioned in help text."""
+    # Check that the help text includes the permissions command
+    import inspect
+    source = inspect.getsource(CommandsMixin._show_help)
+    assert "/permissions" in source
+    assert "Change permission mode" in source


### PR DESCRIPTION
Adds a new slash command `/permissions` to allow users to switch between two permission modes: `prompt` and `auto` from inside kon.