### PR TITLE
Add textual bell for approval

### DIFF
--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -968,6 +968,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
                         case ToolApprovalEvent(
                             tool_call_id=id, tool_name=name, display=disp, future=f
                         ):
+                            self.app.bell()
                             chat.show_tool_approval(id, preview=disp or None)
                             self._approval_future = f
                             self._approval_tool_id = id


### PR DESCRIPTION
Play the console 'bell'.

For terminals that support a bell, this typically makes a notification or error sound.

Some terminals may make no sound or display a visual bell indicator, depending on configuration.

<img width="2439" height="1573" alt="approval-bell" src="https://github.com/user-attachments/assets/a1269eb2-7a1d-4a38-ac86-d8ccb5cdf17b" />

