### PR TITLE
feat: add DeepSeek provider

### DIFF
--- a/src/kon/defaults/config.toml
+++ b/src/kon/defaults/config.toml
@@ -80,3 +80,10 @@ mode = "prompt" # "prompt" or "auto"
 enabled = false
 # Audio playback volume from 0.0 (muted) to 1.0 (full volume).
 volume = 0.5
+
+# Example: DeepSeek provider
+# export DEEPSEEK_API_KEY="sk-your-api-key"
+#
+# Then set in [llm]:
+# default_provider = "deepseek"
+# default_model = "deepseek-v4-flash"

--- a/src/kon/llm/base.py
+++ b/src/kon/llm/base.py
@@ -16,6 +16,7 @@ ENV_API_KEY_MAP: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "google": "GEMINI_API_KEY",
     "azure-ai-foundry": "AZURE_AI_FOUNDRY_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
 }
 
 

--- a/src/kon/llm/models.py
+++ b/src/kon/llm/models.py
@@ -57,6 +57,25 @@ MODELS: dict[str, Model] = {
         supports_thinking=True,
         vision_model="glm-4v-flash",
     ),
+    # DeepSeek models (OpenAI-compatible Chat Completions API)
+    "deepseek-v4-flash": Model(
+        id="deepseek-v4-flash",
+        provider="deepseek",
+        api=ApiType.OPENAI_COMPLETIONS,
+        base_url="https://api.deepseek.com",
+        max_tokens=8192,
+        supports_images=False,
+        supports_thinking=True,
+    ),
+    "deepseek-v4-pro": Model(
+        id="deepseek-v4-pro",
+        provider="deepseek",
+        api=ApiType.OPENAI_COMPLETIONS,
+        base_url="https://api.deepseek.com",
+        max_tokens=8192,
+        supports_images=False,
+        supports_thinking=True,
+    ),
     # GitHub Copilot models - Claude (uses Anthropic Messages API for thinking support)
     "claude-sonnet-4.6-copilot": Model(
         id="claude-sonnet-4.6",

--- a/src/kon/llm/providers/__init__.py
+++ b/src/kon/llm/providers/__init__.py
@@ -21,6 +21,7 @@ API_TYPE_TO_PROVIDER_CLASS: dict[ApiType, type[BaseProvider]] = {
 PROVIDER_API_BY_NAME: dict[str, ApiType] = {
     "openai": ApiType.OPENAI_COMPLETIONS,
     "zhipu": ApiType.OPENAI_COMPLETIONS,
+    "deepseek": ApiType.OPENAI_COMPLETIONS,
     "github-copilot": ApiType.GITHUB_COPILOT,
     "openai-responses": ApiType.OPENAI_RESPONSES,
     "openai-codex": ApiType.OPENAI_CODEX_RESPONSES,

--- a/src/kon/llm/providers/openai_compat.py
+++ b/src/kon/llm/providers/openai_compat.py
@@ -14,7 +14,7 @@ def _hostname(base_url: str | None) -> str | None:
 def supports_developer_role(provider: str | None, base_url: str | None) -> bool:
     provider_name = (provider or "").strip().lower()
 
-    if provider_name in {"zai", "zhipu", "github-copilot"}:
+    if provider_name in {"zai", "zhipu", "github-copilot", "deepseek"}:
         return False
 
     hostname = _hostname(base_url)

--- a/src/kon/llm/providers/openai_completions.py
+++ b/src/kon/llm/providers/openai_completions.py
@@ -55,6 +55,7 @@ def _detect_compat(provider: str, base_url: str, model: str = "") -> OpenAICompl
         or normalized_provider == "zhipu"
         or "api.z.ai" in normalized_base_url
     )
+    is_deepseek = normalized_provider == "deepseek" or "api.deepseek.com" in normalized_base_url
 
     if is_zai:
         return OpenAICompletionsCompat(
@@ -62,6 +63,11 @@ def _detect_compat(provider: str, base_url: str, model: str = "") -> OpenAICompl
             supports_developer_role=False,
             supports_reasoning_effort=False,
             thinking_format="zai",
+        )
+
+    if is_deepseek:
+        return OpenAICompletionsCompat(
+            supports_store=False, supports_developer_role=False, supports_reasoning_effort=False
         )
 
     if is_local_base_url(base_url) and "gemma" in normalized_model:
@@ -91,14 +97,14 @@ class OpenAICompletionsProvider(BaseProvider):
 
         api_key = resolve_api_key(
             config.api_key,
-            env_vars=("OPENAI_API_KEY", "ZAI_API_KEY"),
+            env_vars=("DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ZAI_API_KEY"),
             base_url=config.base_url,
             auth_mode=config.openai_compat_auth_mode,
         )
         if not api_key:
             raise ValueError(
                 f"No API key found for {self.name}. "
-                "Set OPENAI_API_KEY or ZAI_API_KEY environment variable, "
+                "Set OPENAI_API_KEY, DEEPSEEK_API_KEY, or ZAI_API_KEY environment variable, "
                 'or configure llm.auth.openai_compat = "auto"/"none" for local endpoints.'
             )
         self._client = AsyncOpenAI(

--- a/tests/test_model_provider_resolution.py
+++ b/tests/test_model_provider_resolution.py
@@ -28,3 +28,10 @@ def test_get_model_prefers_provider_for_gpt_5_4():
     assert copilot.provider == "github-copilot"
     assert openai.provider == "openai-codex"
     assert copilot.api != openai.api
+
+
+def test_get_model_resolves_deepseek_models():
+    model = get_model("deepseek-v4-flash", "deepseek")
+
+    assert model is not None
+    assert model.provider == "deepseek"


### PR DESCRIPTION
## Summary

Adds DeepSeek as a first-class OpenAI-compatible provider.

This registers the `deepseek` provider id, adds static entries for `deepseek-v4-flash` and `deepseek-v4-pro`, supports `DEEPSEEK_API_KEY`, and disables OpenAI-specific compatibility features DeepSeek does not support.

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run python -m pyright .`
- `uv run python -m pytest`
