### PR TITLE
feat(permissions): add keyboard nav to approval popup

### DIFF
--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -178,6 +178,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         self._current_block_type: str | None = None
         self._approval_future: asyncio.Future[ApprovalResponse] | None = None
         self._approval_tool_id: str | None = None
+        self._approval_selection: ApprovalResponse = ApprovalResponse.APPROVE
         self._hide_thinking = False
         self._fd_path: str | None = None
         self._selection_mode: SelectionMode | None = None
@@ -777,10 +778,29 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
     def on_key(self, event: events.Key) -> None:
         if self._approval_future is None or self._approval_future.done():
             return
+        # Direct y/n keys still work and submit immediately, matching prior
+        # behaviour. Left/right move the highlight between the two buttons
+        # without submitting; enter submits the highlighted button.
         if event.key in ("y", "Y"):
             self._approval_future.set_result(ApprovalResponse.APPROVE)
         elif event.key in ("n", "N"):
             self._approval_future.set_result(ApprovalResponse.DENY)
+        elif event.key in ("left", "right"):
+            self._approval_selection = (
+                ApprovalResponse.DENY
+                if self._approval_selection == ApprovalResponse.APPROVE
+                else ApprovalResponse.APPROVE
+            )
+            if self._approval_tool_id is not None:
+                chat = self.query_one("#chat-log", ChatLog)
+                chat.update_tool_approval_selection(
+                    self._approval_tool_id, self._approval_selection
+                )
+            event.prevent_default()
+            event.stop()
+            return
+        elif event.key == "enter":
+            self._approval_future.set_result(self._approval_selection)
         else:
             return
         event.prevent_default()
@@ -972,7 +992,10 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
                             tool_call_id=id, tool_name=name, display=disp, future=f
                         ):
                             self.app.bell()
-                            chat.show_tool_approval(id, preview=disp or None)
+                            self._approval_selection = ApprovalResponse.APPROVE
+                            chat.show_tool_approval(
+                                id, preview=disp or None, selected=self._approval_selection
+                            )
                             self._approval_future = f
                             self._approval_tool_id = id
 

--- a/src/kon/ui/blocks.py
+++ b/src/kon/ui/blocks.py
@@ -10,6 +10,7 @@ from textual.message import Message
 from textual.widgets import Label, Static
 
 from kon import config
+from kon.permissions import ApprovalResponse
 
 from .formatting import format_markdown, strip_markdown_for_collapsed_text
 
@@ -203,6 +204,8 @@ class ToolBlock(Static):
         self._ui_details: str | None = None
         self._success: bool | None = None
         self._awaiting_approval: bool = False
+        self._approval_preview: str | None = None
+        self._approval_selection: ApprovalResponse = ApprovalResponse.APPROVE
         self.add_class("tool-block")
         self._set_state(None)
 
@@ -293,24 +296,42 @@ class ToolBlock(Static):
         else:
             self.add_class("-error")
 
-    def show_approval(self, preview: str | None = None) -> None:
+    def show_approval(
+        self,
+        preview: str | None = None,
+        selected: ApprovalResponse | None = None,
+    ) -> None:
         self._awaiting_approval = True
+        self._approval_preview = preview
+        if selected is not None:
+            self._approval_selection = selected
         self._set_state(None)
         self.query_one("#tool-header", Label).update(self._format_header())
+        self._render_approval_output()
+
+    def update_approval_selection(self, selected: ApprovalResponse) -> None:
+        if not self._awaiting_approval:
+            return
+        self._approval_selection = selected
+        self._render_approval_output()
+
+    def _render_approval_output(self) -> None:
         output = self.query_one("#tool-output", Label)
         self.remove_class("-with-details")
         output.remove_class("-hidden")
         output.remove_class("-details")
 
         content = Text()
-        if preview:
-            content.append_text(self._render_markup_safe(preview))
+        if self._approval_preview:
+            content.append_text(self._render_markup_safe(self._approval_preview))
             content.append("\n\n")
-        content.append_text(self._format_approval_controls())
+        content.append_text(self._format_approval_controls(self._approval_selection))
         output.update(content)
 
     def hide_approval(self) -> None:
         self._awaiting_approval = False
+        self._approval_preview = None
+        self._approval_selection = ApprovalResponse.APPROVE
         self._set_state(None)
         self.query_one("#tool-header", Label).update(self._format_header())
         output = self.query_one("#tool-output", Label)
@@ -319,14 +340,30 @@ class ToolBlock(Static):
         output.add_class("-hidden")
         output.update(Text(""))
 
-    def _format_approval_controls(self) -> Text:
+    def _format_approval_controls(
+        self, selected: ApprovalResponse = ApprovalResponse.APPROVE
+    ) -> Text:
         colors = config.ui.colors
         text = Text()
-        text.append("[y] approve ", style=Style(bgcolor=colors.accent, color=colors.bg, bold=True))
-        text.append("  ")
-        text.append(
-            "[n] deny ", style=Style(bgcolor=colors.panel_alt, color=colors.dim, bold=True)
+        # The non-selected button uses the dim panel_alt background; the
+        # selected one gets the accent. Direct y/n keys submit immediately;
+        # left/right move the highlight; enter submits the highlight.
+        approve_selected = selected == ApprovalResponse.APPROVE
+        approve_style = Style(
+            bgcolor=colors.accent if approve_selected else colors.panel_alt,
+            color=colors.bg if approve_selected else colors.dim,
+            bold=True,
         )
+        deny_style = Style(
+            bgcolor=colors.accent if not approve_selected else colors.panel_alt,
+            color=colors.bg if not approve_selected else colors.dim,
+            bold=True,
+        )
+        text.append("[y] approve ", style=approve_style)
+        text.append("  ")
+        text.append("[n] deny ", style=deny_style)
+        text.append("  ")
+        text.append("(← → enter)", style=Style(color=colors.dim))
         return text
 
     def update_call_msg(self, call_msg: str) -> None:

--- a/src/kon/ui/chat.py
+++ b/src/kon/ui/chat.py
@@ -8,6 +8,7 @@ from textual.timer import Timer
 from textual.widgets import Label
 
 from kon import config
+from kon.permissions import ApprovalResponse
 
 from .blocks import (
     ContentBlock,
@@ -393,11 +394,23 @@ class ChatLog(VerticalScroll):
             block.update_call_msg(call_msg)
             self._scroll_if_anchored(animate=False)
 
-    def show_tool_approval(self, tool_id: str, preview: str | None = None) -> None:
+    def show_tool_approval(
+        self,
+        tool_id: str,
+        preview: str | None = None,
+        selected: ApprovalResponse | None = None,
+    ) -> None:
         block = self._tool_blocks.get(tool_id)
         if block:
-            block.show_approval(preview=preview)
+            block.show_approval(preview=preview, selected=selected)
             self._scroll_if_anchored(animate=False)
+
+    def update_tool_approval_selection(
+        self, tool_id: str, selected: ApprovalResponse
+    ) -> None:
+        block = self._tool_blocks.get(tool_id)
+        if block:
+            block.update_approval_selection(selected)
 
     def hide_tool_approval(self, tool_id: str) -> None:
         block = self._tool_blocks.get(tool_id)

--- a/src/kon/ui/input.py
+++ b/src/kon/ui/input.py
@@ -54,7 +54,8 @@ class Kon(TextArea):
 
     async def _on_key(self, event: events.Key) -> None:
         future = getattr(self.app, "_approval_future", None)
-        if future and not future.done() and event.key in ("y", "Y", "n", "N"):
+        approval_keys = ("y", "Y", "n", "N", "left", "right", "enter")
+        if future and not future.done() and event.key in approval_keys:
             app_on_key = getattr(self.app, "on_key", None)
             if callable(app_on_key):
                 app_on_key(event)

--- a/src/kon/ui/input.py
+++ b/src/kon/ui/input.py
@@ -54,7 +54,9 @@ class Kon(TextArea):
 
     async def _on_key(self, event: events.Key) -> None:
         future = getattr(self.app, "_approval_future", None)
-        approval_keys = ("y", "Y", "n", "N", "left", "right", "enter")
+        approval_keys = ("y", "Y", "n", "N")
+        if not self.text:
+            approval_keys += ("left", "right", "enter")
         if future and not future.done() and event.key in approval_keys:
             app_on_key = getattr(self.app, "on_key", None)
             if callable(app_on_key):

--- a/tests/ui/test_app_approval_keys.py
+++ b/tests/ui/test_app_approval_keys.py
@@ -1,0 +1,91 @@
+from kon.permissions import ApprovalResponse
+from kon.ui.app import Kon
+
+
+class FakeKeyEvent:
+    def __init__(self, key: str) -> None:
+        self.key = key
+        self.prevented = False
+        self.stopped = False
+
+    def prevent_default(self) -> None:
+        self.prevented = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+class FakeChat:
+    def __init__(self) -> None:
+        self.selections: list[tuple[str, ApprovalResponse]] = []
+
+    def update_tool_approval_selection(self, tool_id: str, selection: ApprovalResponse) -> None:
+        self.selections.append((tool_id, selection))
+
+
+class FakeFuture:
+    def __init__(self) -> None:
+        self._done = False
+        self._result: ApprovalResponse | None = None
+
+    def done(self) -> bool:
+        return self._done
+
+    def set_result(self, result: ApprovalResponse) -> None:
+        self._done = True
+        self._result = result
+
+    def result(self) -> ApprovalResponse | None:
+        return self._result
+
+
+class FakeKon:
+    def __init__(self, future: FakeFuture) -> None:
+        self._approval_future = future
+        self._approval_selection = ApprovalResponse.APPROVE
+        self._approval_tool_id = "tool-1"
+        self.chat = FakeChat()
+        self.cleared = False
+
+    def query_one(self, selector, widget_type):
+        assert selector == "#chat-log"
+        return self.chat
+
+    def _clear_approval_state(self) -> None:
+        self.cleared = True
+
+
+def test_approval_left_right_toggles_selection_without_submitting() -> None:
+    future = FakeFuture()
+    app = FakeKon(future)
+
+    left = FakeKeyEvent("left")
+    Kon.on_key(app, left)  # type: ignore[arg-type]
+
+    assert app._approval_selection == ApprovalResponse.DENY
+    assert not future.done()
+    assert app.chat.selections == [("tool-1", ApprovalResponse.DENY)]
+    assert left.prevented is True
+    assert left.stopped is True
+    assert app.cleared is False
+
+    right = FakeKeyEvent("right")
+    Kon.on_key(app, right)  # type: ignore[arg-type]
+
+    assert app._approval_selection == ApprovalResponse.APPROVE
+    assert not future.done()
+    assert app.chat.selections[-1] == ("tool-1", ApprovalResponse.APPROVE)
+
+
+def test_approval_enter_submits_current_selection() -> None:
+    future = FakeFuture()
+    app = FakeKon(future)
+    app._approval_selection = ApprovalResponse.DENY
+
+    event = FakeKeyEvent("enter")
+    Kon.on_key(app, event)  # type: ignore[arg-type]
+
+    assert future.result() == ApprovalResponse.DENY
+    assert event.prevented is True
+    assert event.stopped is True
+    assert app.cleared is True


### PR DESCRIPTION
Resolves #42.

The permissions popup now responds to left/right and enter, in addition to the existing y/n shortcuts:

- **left / right** toggles which button is highlighted between **approve** and **deny**.
- **enter** submits the highlighted button.
- **y / Y / n / N** still work exactly as before and still submit immediately.

## Visual

Highlight uses the same accent / panel\_alt colour pair as the existing approve button so the selection visibly inverts. A small \`(← → enter)\` affordance is rendered after the buttons so the navigation is discoverable.

## Wiring

- \`InputBox._on_key\` forwards \`left\`, \`right\`, and \`enter\` to \`App.on_key\` while \`_approval_future\` is pending (same path the y/n forward already uses).
- \`App.on_key\` updates \`_approval_selection\` on left/right (without submitting) and submits \`_approval_selection\` on enter.
- \`ChatLog.update_tool_approval_selection\` re-renders just the button row.
- \`ToolBlock\` now tracks \`_approval_selection\` and \`_approval_preview\` so the selection re-render doesn't drop the preview content.

The selection resets to **approve** on each new prompt.

## Tests

\`uv run pytest tests/\` — 467 passed in 6.9s.