### PR TITLE
fix: enforce output cap on shell-mode bash

### DIFF
--- a/src/kon/tools/bash.py
+++ b/src/kon/tools/bash.py
@@ -81,9 +81,12 @@ def _truncate_tail(text: str) -> TruncationResult:
 
     for i in range(total_lines - 1, -1, -1):
         line = lines[i]
-        line_bytes = len(line.encode("utf-8")) + (1 if output_lines else 0)
+        encoded_line = line.encode("utf-8")
+        line_bytes = len(encoded_line) + (1 if output_lines else 0)
 
         if output_bytes + line_bytes > MAX_OUTPUT_BYTES:
+            if not output_lines:
+                output_lines.append(encoded_line[-MAX_OUTPUT_BYTES:].decode("utf-8", "ignore"))
             break
         if len(output_lines) >= MAX_OUTPUT_LINES:
             break
@@ -186,7 +189,7 @@ class BashTool(BaseTool):
         self,
         params: BashParams,
         cancel_event: asyncio.Event | None = None,
-        show_full_output: bool = False,
+        inline_output: bool = False,
     ) -> ToolResult:
         if not params.command.strip():
             msg = "Command cannot be empty"
@@ -288,28 +291,23 @@ class BashTool(BaseTool):
                 full_output += f"\n[stderr]\n{stderr}" if full_output else f"[stderr]\n{stderr}"
             full_output = full_output.rstrip()
 
-            no_of_output_line = len(full_output.split("\n"))
-
-            # Apply truncation unless show_full_output is True
-            if show_full_output:
-                trunc = TruncationResult(full_output, False, no_of_output_line, no_of_output_line)
-            else:
-                trunc = _truncate_tail(full_output)
-                temp_file_path = None
-                if trunc.truncated:
+            trunc = _truncate_tail(full_output)
+            if trunc.truncated:
+                marker = (
+                    f"\n\n[output truncated to last {trunc.lines_kept} lines "
+                    f"of {trunc.total_lines}"
+                )
+                if inline_output:
+                    marker += "]"
+                else:
                     temp_file_path = _write_full_output_to_temp(full_output)
-                    trunc.content += (
-                        f"\n\n[output truncated to last {trunc.lines_kept} lines "
-                        f"of {trunc.total_lines}; full output: {temp_file_path}]"
-                    )
+                    marker += f"; full output: {temp_file_path}]"
+                trunc.content += marker
 
             result_text = trunc.content or "(no output)"
 
-            # Use unlimited lines for display when show_full_output is True
-            if show_full_output:
-                display_text = self._format_display(trunc.content, max_lines=no_of_output_line)
-            else:
-                display_text = self._format_display(trunc.content)
+            display_max = sys.maxsize if inline_output else 5
+            display_text = self._format_display(trunc.content, max_lines=display_max)
 
             non_empty_lines = [line for line in (trunc.content or "").split("\n") if line.strip()]
             is_single_line = len(non_empty_lines) <= 1

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -1045,8 +1045,8 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         # Determine if we should send output to LLM
         send_to_llm = display_text.startswith("!!")
 
-        # Show full output for !command, truncated for !!command
-        show_full_output = not send_to_llm
+        # Render output inline in chat for !command with truncated summary for !!command
+        inline_output = not send_to_llm
 
         command_text = display_text[2:] if send_to_llm else display_text[1:]
         command_text = command_text.strip()
@@ -1060,12 +1060,11 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         # Execute the command
         self._is_running = True
         self.run_worker(
-            self._execute_shell_command(command_text, send_to_llm, show_full_output),
-            exclusive=True,
+            self._execute_shell_command(command_text, send_to_llm, inline_output), exclusive=True
         )
 
     async def _execute_shell_command(
-        self, command: str, send_to_llm: bool, show_full_output: bool
+        self, command: str, send_to_llm: bool, inline_output: bool
     ) -> None:
         """Execute a shell command and display the result"""
         chat = self.query_one("#chat-log", ChatLog)
@@ -1082,9 +1081,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
             # Execute the command
             status.set_status("running")
             result = await bash_tool.execute(
-                BashParams(command=command),
-                cancel_event=cancel_event,
-                show_full_output=show_full_output,
+                BashParams(command=command), cancel_event=cancel_event, inline_output=inline_output
             )
 
             # Start tool block

--- a/tests/tools/test_bash_truncation.py
+++ b/tests/tools/test_bash_truncation.py
@@ -1,0 +1,86 @@
+import asyncio
+import tempfile
+
+import pytest
+
+from kon.tools.bash import MAX_OUTPUT_BYTES, MAX_OUTPUT_LINES, BashParams, BashTool
+
+
+class _FakeProcess:
+    def __init__(self, stdout: bytes, stderr: bytes = b"", returncode: int = 0) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+def _patch_subprocess(monkeypatch, proc: _FakeProcess) -> None:
+    async def mock_create(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", mock_create)
+
+
+def _stdout_with_lines(line_count: int) -> bytes:
+    return ("\n".join(f"line{i}" for i in range(1, line_count + 1)) + "\n").encode()
+
+
+@pytest.mark.asyncio
+async def test_inline_output_truncates_without_temp_file_path(monkeypatch):
+    line_count = 5000
+    _patch_subprocess(monkeypatch, _FakeProcess(_stdout_with_lines(line_count)))
+
+    result = await BashTool().execute(BashParams(command="ignored"), inline_output=True)
+
+    assert result.success is True
+    assert result.result is not None
+    assert f"[output truncated to last {MAX_OUTPUT_LINES} lines of {line_count}]" in result.result
+    assert "full output:" not in result.result
+    # Bounded: kept lines + a separator + the marker line.
+    assert result.result.count("\n") <= MAX_OUTPUT_LINES + 2
+
+
+@pytest.mark.asyncio
+async def test_default_truncates_with_temp_file_path(monkeypatch):
+    line_count = 5000
+    _patch_subprocess(monkeypatch, _FakeProcess(_stdout_with_lines(line_count)))
+    fake_path = f"{tempfile.gettempdir()}/kon-bash-fake.log"
+    monkeypatch.setattr("kon.tools.bash._write_full_output_to_temp", lambda _: fake_path)
+
+    result = await BashTool().execute(BashParams(command="ignored"))
+
+    assert result.success is True
+    assert result.result is not None
+    assert (
+        f"[output truncated to last {MAX_OUTPUT_LINES} lines of {line_count}; "
+        f"full output: {fake_path}]"
+    ) in result.result
+
+
+@pytest.mark.asyncio
+async def test_inline_output_keeps_excerpt_for_single_oversized_line(monkeypatch):
+    oversized_line = b"a" * (MAX_OUTPUT_BYTES + 1)
+    _patch_subprocess(monkeypatch, _FakeProcess(oversized_line))
+
+    result = await BashTool().execute(BashParams(command="ignored"), inline_output=True)
+
+    assert result.success is True
+    assert result.result is not None
+    assert result.result.startswith("a" * 100)
+    assert "[output truncated to last 1 lines of 1]" in result.result
+    assert "full output:" not in result.result
+    assert len(result.result.encode()) < MAX_OUTPUT_BYTES + 200
+
+
+@pytest.mark.asyncio
+async def test_short_output_is_not_truncated(monkeypatch):
+    _patch_subprocess(monkeypatch, _FakeProcess(b"hi\n"))
+
+    result = await BashTool().execute(BashParams(command="ignored"), inline_output=True)
+
+    assert result.success is True
+    assert result.result is not None
+    assert "truncated" not in result.result
+    assert result.result.strip() == "hi"

--- a/tests/ui/test_shell_command_detection.py
+++ b/tests/ui/test_shell_command_detection.py
@@ -105,7 +105,9 @@ async def test_execute_shell_command_basic():
     mock_result.ui_details = None
     mock_result.ui_summary = None
 
-    with patch.object(BashTool, "execute", new_callable=AsyncMock, return_value=mock_result):
+    with patch.object(
+        BashTool, "execute", new_callable=AsyncMock, return_value=mock_result
+    ) as execute:
         # Call the method
         await Kon._execute_shell_command(app, "ls -la", False, True)
 
@@ -119,6 +121,7 @@ async def test_execute_shell_command_basic():
     # Verify tool block result was set
     tool_block = mock_chat.start_tool.return_value
     tool_block.set_result.assert_called_once_with("test output", None, True, markup=False)
+    assert execute.call_args.kwargs["inline_output"] is True
 
     # Verify app state was reset
     assert app._is_running is False
@@ -147,7 +150,9 @@ async def test_execute_shell_command_with_llm():
     # Mock the _run_agent method
     app._run_agent = AsyncMock()
 
-    with patch.object(BashTool, "execute", new_callable=AsyncMock, return_value=mock_result):
+    with patch.object(
+        BashTool, "execute", new_callable=AsyncMock, return_value=mock_result
+    ) as execute:
         # Call the method with send_to_llm=True
         await Kon._execute_shell_command(app, "git status", True, False)
 
@@ -158,6 +163,7 @@ async def test_execute_shell_command_with_llm():
     assert "git status output" in call_args
     assert "What would you like me to do with this?" in call_args
     assert app._interrupt_requested is False
+    assert execute.call_args.kwargs["inline_output"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

As mentioned [here](https://github.com/0xku/kon/pull/37#issuecomment-4349600704), `!command` can flood the UI when a command prints a lot of output, for example `fd .` in a large repo. The bash tool already caps normal tool output and `!!command`, but shell inline output was still shown in full.

## Fix

Run shell output through the same tail truncation path for both modes. `!command` keeps a bounded inline result and omits the temp file path, while normal tool execution and `!!command` still include the temp file when output is truncated.

The truncation path also keeps a tail excerpt for a single oversized line instead of returning only the truncation marker. Tests cover inline truncation, default temp file behavior, oversized lines, and the `!` / `!!` routing.
