### PR TITLE
fix: harden web_fetch against SSRF

### DIFF
--- a/src/kon/tools/web_fetch.py
+++ b/src/kon/tools/web_fetch.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import socket
 from urllib.parse import urlparse
 
 from curl_cffi import AsyncSession, CurlOpt
@@ -39,16 +40,79 @@ _HIDDEN_XPATH = (
 )
 
 
+class _FetchRefusalError(Exception):
+    pass
+
+
 def _looks_like_challenge(html: str) -> bool:
     head = html[:4096].lower()
     return any(sig in head for sig in _CHALLENGE_SIGNATURES)
 
 
-def _is_link_local(ip: str) -> bool:
+_WELL_KNOWN_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
+def _is_public_ip(ip: str) -> bool:
     try:
-        return ipaddress.ip_address(ip).is_link_local
+        parsed = ipaddress.ip_address(ip)
     except ValueError:
-        return True  # fail closed
+        return False
+    if not parsed.is_global or parsed.is_multicast:
+        return False
+    # NAT64 is marked global but can wrap a private IPv4 (e.g., 169.254.169.254).
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed in _WELL_KNOWN_NAT64_PREFIX:
+        mapped_ipv4 = ipaddress.IPv4Address(int(parsed) & 0xFFFFFFFF)
+        return mapped_ipv4.is_global and not mapped_ipv4.is_multicast
+    return True
+
+
+def _parse_fetch_url(url: str) -> tuple[str, int]:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise _FetchRefusalError(f"unsupported scheme {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise _FetchRefusalError("missing host")
+    try:
+        port = parsed.port
+    except ValueError:
+        raise _FetchRefusalError("invalid port") from None
+    return parsed.hostname, port or (443 if parsed.scheme == "https" else 80)
+
+
+async def _resolve_host_addresses(host: str, port: int) -> list[str]:
+    loop = asyncio.get_running_loop()
+    results = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    return list(dict.fromkeys(sockaddr[0] for *_, sockaddr in results))
+
+
+def _curl_resolve_entry(host: str, port: int, addresses: list[str]) -> str:
+    formatted_addresses = ",".join(
+        f"[{ip}]" if ipaddress.ip_address(ip).version == 6 else ip for ip in addresses
+    )
+    return f"{host}:{port}:{formatted_addresses}"
+
+
+async def _prepare_curl_resolve(url: str, cancel_event: asyncio.Event | None = None) -> list[str]:
+    host, port = _parse_fetch_url(url)
+
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        resolve_task = asyncio.create_task(_resolve_host_addresses(host, port))
+        try:
+            addresses = await await_task_or_cancel(resolve_task, cancel_event)
+        except ToolCancelledError:
+            raise
+        except Exception:
+            raise _FetchRefusalError("host did not resolve") from None
+        public_addresses = [ip for ip in addresses if _is_public_ip(ip)]
+        if not public_addresses:
+            raise _FetchRefusalError("host did not resolve to a public address") from None
+        return [_curl_resolve_entry(host, port, public_addresses)]
+
+    if not _is_public_ip(host):
+        raise _FetchRefusalError(f"non-public address ({host})")
+    return []
 
 
 def _extract_markdown(html: str) -> str | None:
@@ -89,16 +153,25 @@ class WebFetchTool(BaseTool):
     async def execute(
         self, params: WebFetchParams, cancel_event: asyncio.Event | None = None
     ) -> ToolResult:
-        scheme = urlparse(params.url).scheme
-        if scheme not in ("http", "https"):
-            msg = f"Refused: unsupported scheme {scheme!r}"
+        try:
+            curl_resolve = await _prepare_curl_resolve(params.url, cancel_event)
+        except ToolCancelledError:
+            return ToolResult(success=False, result="Fetch aborted")
+        except _FetchRefusalError as e:
+            msg = f"Refused: {e}"
             return ToolResult(success=False, result=msg, ui_summary=f"[red]{msg}[/red]")
 
         try:
+            curl_options = {
+                CurlOpt.MAXFILESIZE_LARGE: MAX_RESPONSE_BYTES,
+                CurlOpt.PROTOCOLS_STR: "http,https",
+                CurlOpt.REDIR_PROTOCOLS_STR: "http,https",
+            }
+            if curl_resolve:
+                curl_options[CurlOpt.RESOLVE] = curl_resolve
+
             async with AsyncSession(
-                impersonate="chrome131",
-                allow_redirects="safe",
-                curl_options={CurlOpt.MAXFILESIZE_LARGE: MAX_RESPONSE_BYTES},
+                impersonate="chrome131", allow_redirects="safe", curl_options=curl_options
             ) as session:
                 fetch_task = asyncio.create_task(session.get(params.url, timeout=REQUEST_TIMEOUT))
                 response = await await_task_or_cancel(fetch_task, cancel_event)
@@ -108,8 +181,8 @@ class WebFetchTool(BaseTool):
             msg = f"Fetch failed: {e}"
             return ToolResult(success=False, result=msg, ui_summary=f"[red]{msg}[/red]")
 
-        if _is_link_local(response.primary_ip):
-            msg = f"Refused: link-local address ({response.primary_ip or 'unknown'})"
+        if not _is_public_ip(response.primary_ip):
+            msg = f"Refused: non-public address ({response.primary_ip or 'unknown'})"
             return ToolResult(success=False, result=msg, ui_summary=f"[red]{msg}[/red]")
 
         # Catches decompression bombs (MAXFILESIZE_LARGE only bounds wire bytes).

--- a/tests/tools/test_web_fetch.py
+++ b/tests/tools/test_web_fetch.py
@@ -1,0 +1,95 @@
+import pytest
+from curl_cffi import CurlOpt
+
+from kon.tools import web_fetch
+from kon.tools.web_fetch import WebFetchParams, WebFetchTool
+
+
+def _fail_session(*args, **kwargs):
+    raise AssertionError("fetch should be refused before creating a session")
+
+
+@pytest.mark.parametrize(
+    ("ip", "expected"),
+    [
+        ("127.0.0.1", False),
+        ("10.0.0.1", False),
+        ("192.168.0.1", False),
+        ("169.254.169.254", False),
+        ("100.100.100.200", False),
+        ("::1", False),
+        ("fc00::1", False),
+        ("224.0.0.1", False),
+        ("64:ff9b::169.254.169.254", False),
+        ("93.184.216.34", True),
+        ("2606:2800:220:1:248:1893:25c8:1946", True),
+    ],
+)
+def test_public_ip_policy(ip, expected):
+    assert web_fetch._is_public_ip(ip) is expected
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_refuses_direct_loopback_before_fetch(monkeypatch):
+    monkeypatch.setattr(web_fetch, "AsyncSession", _fail_session)
+
+    result = await WebFetchTool().execute(WebFetchParams(url="http://127.0.0.1:8000/"))
+
+    assert result.success is False
+    assert result.result == "Refused: non-public address (127.0.0.1)"
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_refuses_hostname_that_resolves_to_loopback(monkeypatch):
+    async def resolve_host_addresses(host: str, port: int):
+        assert host == "local.test"
+        assert port == 80
+        return ["127.0.0.1"]
+
+    monkeypatch.setattr(web_fetch, "_resolve_host_addresses", resolve_host_addresses)
+    monkeypatch.setattr(web_fetch, "AsyncSession", _fail_session)
+
+    result = await WebFetchTool().execute(WebFetchParams(url="http://local.test/"))
+
+    assert result.success is False
+    assert result.result == "Refused: host did not resolve to a public address"
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_pins_public_resolution_and_checks_connected_ip(monkeypatch):
+    async def resolve_host_addresses(host: str, port: int):
+        assert host == "example.test"
+        assert port == 443
+        return ["93.184.216.34", "127.0.0.1", "2606:2800:220:1:248:1893:25c8:1946"]
+
+    class FakeResponse:
+        primary_ip = "127.0.0.1"
+        status_code = 200
+        text = "<html><body>secret</body></html>"
+        content = b"<html><body>secret</body></html>"
+
+    class FakeSession:
+        def __init__(self, *, allow_redirects, curl_options, **kwargs):
+            assert allow_redirects == "safe"
+            assert curl_options[CurlOpt.PROTOCOLS_STR] == "http,https"
+            assert curl_options[CurlOpt.REDIR_PROTOCOLS_STR] == "http,https"
+            assert curl_options[CurlOpt.RESOLVE] == [
+                "example.test:443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]"
+            ]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, timeout):
+            return FakeResponse()
+
+    monkeypatch.setattr(web_fetch, "_resolve_host_addresses", resolve_host_addresses)
+    monkeypatch.setattr(web_fetch, "AsyncSession", FakeSession)
+
+    result = await WebFetchTool().execute(WebFetchParams(url="https://example.test/"))
+
+    assert result.success is False
+    assert result.result == "Refused: non-public address (127.0.0.1)"


### PR DESCRIPTION
## Summary

Since `web_fetch` is allowed automatically and the LLM picks the url, a malicious page or prompt could point it at localhost or a private network service without asking the user (SSRF). The previous guard prevented link local IPs after curl connected, but other private ranges reachable through the url itself or DNS resolution had been overlooked.

This expands the guard to require public addresses before fetching. Hostnames are resolved upfront and pinned into curl so curl uses the checked addresses. Redirects stay limited to http(s), and the connected IP check remains as a fallback.

I also added tests around the main SSRF cases and the public address policy.
