### PR TITLE
fix: refresh info bar git branch

### DIFF
--- a/src/kon/git_branch.py
+++ b/src/kon/git_branch.py
@@ -1,0 +1,90 @@
+import os
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GitPaths:
+    repo_dir: str
+    common_git_dir: str
+    head_path: str
+
+
+def find_git_paths(cwd: str) -> GitPaths | None:
+    """Find git metadata paths for regular repos and worktrees."""
+    directory = os.path.abspath(cwd)
+    while True:
+        git_path = os.path.join(directory, ".git")
+        if os.path.exists(git_path):
+            try:
+                if os.path.isfile(git_path):
+                    with open(git_path, encoding="utf-8") as f:
+                        content = f.read().strip()
+                    if content.startswith("gitdir: "):
+                        git_dir = os.path.abspath(
+                            os.path.join(directory, content.removeprefix("gitdir: ").strip())
+                        )
+                        head_path = os.path.join(git_dir, "HEAD")
+                        if not os.path.exists(head_path):
+                            return None
+                        common_dir_path = os.path.join(git_dir, "commondir")
+                        if os.path.exists(common_dir_path):
+                            with open(common_dir_path, encoding="utf-8") as f:
+                                common_dir = f.read().strip()
+                            common_git_dir = os.path.abspath(os.path.join(git_dir, common_dir))
+                        else:
+                            common_git_dir = git_dir
+                        return GitPaths(directory, common_git_dir, head_path)
+                elif os.path.isdir(git_path):
+                    head_path = os.path.join(git_path, "HEAD")
+                    if not os.path.exists(head_path):
+                        return None
+                    return GitPaths(directory, git_path, head_path)
+            except OSError:
+                return None
+
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return None
+        directory = parent
+
+
+def _resolve_branch_with_git(repo_dir: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "--no-optional-locks", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def resolve_git_branch(cwd: str) -> str:
+    """Resolve current git branch, returning an empty string outside git repos."""
+    git_paths = find_git_paths(cwd)
+    if git_paths is None:
+        return ""
+
+    try:
+        with open(git_paths.head_path, encoding="utf-8") as f:
+            content = f.read().strip()
+    except OSError:
+        return ""
+
+    prefix = "ref: refs/heads/"
+    if content.startswith(prefix):
+        branch = content.removeprefix(prefix)
+        if branch == ".invalid":
+            return _resolve_branch_with_git(git_paths.repo_dir) or "detached"
+        return branch
+
+    return "detached"

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -88,6 +88,7 @@ except PackageNotFoundError:
     VERSION = "0.3.7"
 
 _NOTIFY_EVENTS = (AgentEndEvent, ToolApprovalEvent)
+_GIT_BRANCH_REFRESH_INTERVAL_SECONDS = 1.0
 
 
 class Kon(CommandsMixin, SessionUIMixin, App[None]):
@@ -400,6 +401,8 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
             info_bar.set_file_changes(self._runtime.session.file_changes_summary())
             chat.add_info_message("Resumed session")
 
+        self.set_interval(_GIT_BRANCH_REFRESH_INTERVAL_SECONDS, self._refresh_git_branch)
+
         self._startup_complete = True
         self._show_pending_update_notice_if_idle()
         input_box.focus()
@@ -407,6 +410,10 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         import gc
 
         gc.freeze()
+
+    def _refresh_git_branch(self) -> None:
+        info_bar = self.query_one("#info-bar", InfoBar)
+        info_bar.refresh_git_branch()
 
     async def _collect_file_paths(self) -> None:
         """Collect file paths using glob (fallback when fd is unavailable)."""

--- a/src/kon/ui/widgets.py
+++ b/src/kon/ui/widgets.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import time
 from typing import ClassVar
 
@@ -14,6 +13,7 @@ from textual.widgets import Label
 
 from kon import config
 from kon.config import PermissionMode
+from kon.git_branch import resolve_git_branch
 
 from .formatting import format_tokens
 
@@ -26,20 +26,7 @@ def format_path(path: str) -> str:
 
 
 def get_git_branch(cwd: str) -> str:
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=1,
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip()
-            return branch if branch else ""
-    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
-        pass
-    return ""
+    return resolve_git_branch(cwd)
 
 
 class FileChangesModal(ModalScreen[None]):
@@ -145,6 +132,7 @@ class InfoBar(Vertical):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        self._raw_cwd = cwd
         self._cwd = format_path(cwd)
         self._git_branch = get_git_branch(cwd)
         self._model = model
@@ -294,6 +282,15 @@ class InfoBar(Vertical):
         self._model = model
         self._model_provider = provider
         self._label_row2_right.update(self._format_row2_right())
+
+    def set_git_branch(self, branch: str) -> None:
+        if self._git_branch == branch:
+            return
+        self._git_branch = branch
+        self.query_one("#info-cwd", Label).update(self._format_row1_left(), layout=False)
+
+    def refresh_git_branch(self) -> None:
+        self.set_git_branch(get_git_branch(self._raw_cwd))
 
     def set_thinking_level(self, thinking_level: str) -> None:
         self._thinking_level = thinking_level

--- a/tests/test_git_branch.py
+++ b/tests/test_git_branch.py
@@ -1,0 +1,84 @@
+import subprocess
+from pathlib import Path
+
+from kon.git_branch import resolve_git_branch
+
+
+def test_resolve_git_branch_reads_head_directly(tmp_path: Path):
+    repo = tmp_path / "repo"
+    nested = repo / "src"
+    git_dir = repo / ".git"
+    nested.mkdir(parents=True)
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+
+    assert resolve_git_branch(str(nested)) == "main"
+
+
+def test_resolve_git_branch_supports_worktrees(tmp_path: Path):
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    git_dir = repo / ".git" / "worktrees" / "src"
+    common_git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    worktree.mkdir()
+    common_git_dir.mkdir(exist_ok=True)
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n")
+    (git_dir / "HEAD").write_text("ref: refs/heads/feature\n")
+    (git_dir / "commondir").write_text("../..\n")
+
+    assert resolve_git_branch(str(worktree)) == "feature"
+
+
+def test_resolve_git_branch_falls_back_to_git_for_reftable_invalid_head(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/.invalid\n")
+
+    def fake_run(*args, **kwargs):
+        assert args[0] == [
+            "git",
+            "--no-optional-locks",
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "HEAD",
+        ]
+        assert kwargs["cwd"] == str(repo)
+        return subprocess.CompletedProcess(args[0], 0, stdout="main\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert resolve_git_branch(str(repo)) == "main"
+
+
+def test_resolve_git_branch_treats_unresolved_reftable_head_as_detached(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/.invalid\n")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert resolve_git_branch(str(repo)) == "detached"
+
+
+def test_resolve_git_branch_returns_empty_string_outside_repo(tmp_path: Path):
+    assert resolve_git_branch(str(tmp_path)) == ""
+
+
+def test_resolve_git_branch_reports_detached_head(tmp_path: Path):
+    repo = tmp_path / "repo"
+    git_dir = repo / ".git"
+    git_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("abc123\n")
+
+    assert resolve_git_branch(str(repo)) == "detached"

--- a/tests/ui/test_info_bar_permissions.py
+++ b/tests/ui/test_info_bar_permissions.py
@@ -49,3 +49,14 @@ def test_info_bar_updates_permission_mode_without_layout():
 
     assert cast(Any, label.content).plain == "✓✓ auto"
     assert label.layout_values == [False]
+
+
+def test_info_bar_updates_git_branch_without_layout(monkeypatch):
+    info_bar = InfoBar("/tmp", "model")
+    label = _FakeLabel()
+    monkeypatch.setattr(info_bar, "query_one", lambda *args: label)
+
+    info_bar.set_git_branch("feature")
+
+    assert cast(Any, label.content).plain == "/tmp (⌥ feature)"
+    assert label.layout_values == [False]


### PR DESCRIPTION
## Summary
- refresh the info bar git branch every second
- resolve branches from git metadata directly, with worktree and reftable `.invalid` fallback support
- add tests for branch resolution and info bar branch updates

Closes #44.

## Tests
- uv run ruff format .
- uv run ruff check .
- uv run python -m pyright .
- uv run python -m pytest