### PR TITLE
fix: prevent crash when tool output widget doesn't exist yet

### DIFF
--- a/src/kon/ui/blocks.py
+++ b/src/kon/ui/blocks.py
@@ -397,7 +397,12 @@ class ToolBlock(Static):
         self._render_result_output()
 
     def _render_result_output(self) -> None:
-        output = self.query_one("#tool-output", Label)
+        # Check if the output widget exists before trying to query it
+        # (it may not exist if the tool is still pending and compose hasn't run)
+        try:
+            output = self.query_one("#tool-output", Label)
+        except Exception:
+            return
         ui_details = (
             self._ui_details_full if self._expanded and self._ui_details_full else self._ui_details
         )


### PR DESCRIPTION
## Problem

When `Ctrl+O` is pressed to toggle tool output expansion while a tool is still pending (running), the application crashes with:

```
No nodes match '#tool-output' on ToolBlock(name='bash', classes='tool-block -pending')
```

## Root Cause

The issue occurs in `src/kon/ui/blocks.py` in the `ToolBlock` class:

1. `Ctrl+O` triggers `toggle_tool_output_expanded()` in `ChatLog`
2. This calls `set_expanded(expanded)` on all tool blocks
3. `set_expanded()` calls `_render_result_output()`
4. `_render_result_output()` unconditionally queries for `#tool-output` widget
5. When a tool is in `-pending` state, the widget hasn't been composed yet
6. The query fails with `NoNodesMatch` exception