### PR TITLE
fix: harden Codex provider event handling and transport

### DIFF
--- a/src/kon/core/types.py
+++ b/src/kon/core/types.py
@@ -66,6 +66,7 @@ class ToolCallDelta(BaseModel):
     type: Literal["tool_call_delta"] = "tool_call_delta"
     index: int  # Correlates with ToolCallStart.index
     arguments_delta: str
+    replace: bool = False
 
 
 class StreamDone(BaseModel):

--- a/src/kon/llm/providers/openai_codex_responses.py
+++ b/src/kon/llm/providers/openai_codex_responses.py
@@ -241,6 +241,11 @@ class OpenAICodexResponsesProvider(BaseProvider):
         last_tool_call_id: str | None = None
         tool_call_index = 0
 
+        def _resolve_key(item_id: Any) -> str | None:
+            if isinstance(item_id, str) and item_id:
+                return call_key_by_item_id.get(item_id)
+            return last_tool_call_id
+
         def _reconcile(call_data: dict[str, Any], final_args: str) -> ToolCallDelta | None:
             current_args = call_data["arguments"]
             if final_args.startswith(current_args):
@@ -282,8 +287,6 @@ class OpenAICodexResponsesProvider(BaseProvider):
                         initial_args = item.get("arguments")
                         initial_args_text = initial_args if isinstance(initial_args, str) else ""
                         current_tool_calls[full_id] = {
-                            "id": full_id,
-                            "name": name,
                             "arguments": initial_args_text,
                             "index": tool_call_index,
                         }
@@ -301,11 +304,7 @@ class OpenAICodexResponsesProvider(BaseProvider):
                 delta = event.get("delta")
                 if not isinstance(delta, str):
                     continue
-                event_item_id = event.get("item_id")
-                if isinstance(event_item_id, str) and event_item_id:
-                    call_key = call_key_by_item_id.get(event_item_id)
-                else:
-                    call_key = last_tool_call_id
+                call_key = _resolve_key(event.get("item_id"))
                 if not call_key or call_key not in current_tool_calls:
                     continue
                 call_data = current_tool_calls[call_key]
@@ -316,11 +315,7 @@ class OpenAICodexResponsesProvider(BaseProvider):
                 final_args = event.get("arguments")
                 if not isinstance(final_args, str):
                     continue
-                event_item_id = event.get("item_id")
-                if isinstance(event_item_id, str) and event_item_id:
-                    call_key = call_key_by_item_id.get(event_item_id)
-                else:
-                    call_key = last_tool_call_id
+                call_key = _resolve_key(event.get("item_id"))
                 if not call_key or call_key not in current_tool_calls:
                     continue
                 call_data = current_tool_calls[call_key]
@@ -335,17 +330,7 @@ class OpenAICodexResponsesProvider(BaseProvider):
                 final_args = item.get("arguments")
                 if not isinstance(final_args, str):
                     continue
-                call_id_field = item.get("call_id")
-                item_id_field = item.get("id")
-                composite = None
-                if isinstance(call_id_field, str) and isinstance(item_id_field, str):
-                    composite = f"{call_id_field}|{item_id_field}"
-                if composite is not None and composite in current_tool_calls:
-                    call_key = composite
-                elif isinstance(item_id_field, str) and item_id_field:
-                    call_key = call_key_by_item_id.get(item_id_field)
-                else:
-                    call_key = last_tool_call_id
+                call_key = _resolve_key(item.get("id"))
                 if not call_key or call_key not in current_tool_calls:
                     continue
                 call_data = current_tool_calls[call_key]

--- a/src/kon/llm/providers/openai_codex_responses.py
+++ b/src/kon/llm/providers/openai_codex_responses.py
@@ -22,11 +22,12 @@ from ...core.types import (
     ToolDefinition,
     Usage,
 )
-from ..base import BaseProvider, LLMStream, ProviderConfig
+from ..base import BaseProvider, LLMStream
 from ..oauth.openai import get_valid_openai_token, load_openai_credentials
 
 _MAX_RETRIES = 3
 _BASE_DELAY_MS = 1000
+_CONNECT_TIMEOUT_SECONDS = 30
 _OPENAI_BETA_RESPONSES_WEBSOCKETS = "responses_websockets=2026-02-06"
 _WS_FALLBACK_SESSIONS: set[str] = set()
 
@@ -36,7 +37,9 @@ class CodexTransportError(Exception):
 
 
 class CodexNonTransportError(Exception):
-    pass
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 def _format_provider_error(error: Exception) -> str:
@@ -53,10 +56,6 @@ def _is_retryable_status(status: int) -> bool:
 class OpenAICodexResponsesProvider(BaseProvider):
     name = "openai-codex"
     thinking_levels: list[str] = ["none", "minimal", "low", "medium", "high", "xhigh"]  # noqa: RUF012
-
-    def __init__(self, config: ProviderConfig):
-        super().__init__(config)
-        self._websocket_fallback = False
 
     async def _stream_impl(
         self,
@@ -207,9 +206,7 @@ class OpenAICodexResponsesProvider(BaseProvider):
         body = self._build_request_body(messages, system_prompt, tools, temperature)
         session_id = self.config.session_id
 
-        if session_id in _WS_FALLBACK_SESSIONS:
-            self._websocket_fallback = True
-        else:
+        if session_id not in _WS_FALLBACK_SESSIONS:
             emitted = False
             try:
                 websocket_events = self._stream_websocket_events(
@@ -222,11 +219,10 @@ class OpenAICodexResponsesProvider(BaseProvider):
             except CodexNonTransportError as e:
                 yield StreamError(error=_format_provider_error(e))
                 return
-            except Exception as e:
+            except (CodexTransportError, aiohttp.ClientError, OSError) as e:
                 if emitted:
                     yield StreamError(error=_format_provider_error(e))
                     return
-                self._websocket_fallback = True
                 if session_id:
                     _WS_FALLBACK_SESSIONS.add(session_id)
 
@@ -241,8 +237,24 @@ class OpenAICodexResponsesProvider(BaseProvider):
         self, events: AsyncIterator[dict[str, Any]], llm_stream: LLMStream
     ) -> AsyncIterator[StreamPart]:
         current_tool_calls: dict[str, dict[str, Any]] = {}
+        call_key_by_item_id: dict[str, str] = {}
         last_tool_call_id: str | None = None
         tool_call_index = 0
+
+        def _reconcile(call_data: dict[str, Any], final_args: str) -> ToolCallDelta | None:
+            current_args = call_data["arguments"]
+            if final_args.startswith(current_args):
+                missing = final_args[len(current_args) :]
+                if not missing:
+                    return None
+                call_data["arguments"] += missing
+                return ToolCallDelta(index=call_data["index"], arguments_delta=missing)
+            if final_args == current_args:
+                return None
+            call_data["arguments"] = final_args
+            return ToolCallDelta(
+                index=call_data["index"], arguments_delta=final_args, replace=True
+            )
 
         async for event in events:
             event_type = event.get("type")
@@ -267,32 +279,85 @@ class OpenAICodexResponsesProvider(BaseProvider):
                     name = item.get("name")
                     if isinstance(call_id, str) and isinstance(name, str):
                         full_id = f"{call_id}|{item_id}" if isinstance(item_id, str) else call_id
+                        initial_args = item.get("arguments")
+                        initial_args_text = initial_args if isinstance(initial_args, str) else ""
                         current_tool_calls[full_id] = {
                             "id": full_id,
                             "name": name,
-                            "arguments": "",
+                            "arguments": initial_args_text,
                             "index": tool_call_index,
                         }
+                        if isinstance(item_id, str) and item_id:
+                            call_key_by_item_id[item_id] = full_id
                         last_tool_call_id = full_id
                         yield ToolCallStart(index=tool_call_index, id=full_id, name=name)
+                        if initial_args_text:
+                            yield ToolCallDelta(
+                                index=tool_call_index, arguments_delta=initial_args_text
+                            )
                         tool_call_index += 1
 
             elif event_type == "response.function_call_arguments.delta":
                 delta = event.get("delta")
-                if (
-                    isinstance(delta, str)
-                    and last_tool_call_id
-                    and last_tool_call_id in current_tool_calls
-                ):
-                    current_tool_calls[last_tool_call_id]["arguments"] += delta
-                    idx = int(current_tool_calls[last_tool_call_id]["index"])
-                    yield ToolCallDelta(index=idx, arguments_delta=delta)
+                if not isinstance(delta, str):
+                    continue
+                event_item_id = event.get("item_id")
+                if isinstance(event_item_id, str) and event_item_id:
+                    call_key = call_key_by_item_id.get(event_item_id)
+                else:
+                    call_key = last_tool_call_id
+                if not call_key or call_key not in current_tool_calls:
+                    continue
+                call_data = current_tool_calls[call_key]
+                call_data["arguments"] += delta
+                yield ToolCallDelta(index=call_data["index"], arguments_delta=delta)
+
+            elif event_type == "response.function_call_arguments.done":
+                final_args = event.get("arguments")
+                if not isinstance(final_args, str):
+                    continue
+                event_item_id = event.get("item_id")
+                if isinstance(event_item_id, str) and event_item_id:
+                    call_key = call_key_by_item_id.get(event_item_id)
+                else:
+                    call_key = last_tool_call_id
+                if not call_key or call_key not in current_tool_calls:
+                    continue
+                call_data = current_tool_calls[call_key]
+                delta_part = _reconcile(call_data, final_args)
+                if delta_part is not None:
+                    yield delta_part
+
+            elif event_type == "response.output_item.done":
+                item = event.get("item")
+                if not isinstance(item, dict) or item.get("type") != "function_call":
+                    continue
+                final_args = item.get("arguments")
+                if not isinstance(final_args, str):
+                    continue
+                call_id_field = item.get("call_id")
+                item_id_field = item.get("id")
+                composite = None
+                if isinstance(call_id_field, str) and isinstance(item_id_field, str):
+                    composite = f"{call_id_field}|{item_id_field}"
+                if composite is not None and composite in current_tool_calls:
+                    call_key = composite
+                elif isinstance(item_id_field, str) and item_id_field:
+                    call_key = call_key_by_item_id.get(item_id_field)
+                else:
+                    call_key = last_tool_call_id
+                if not call_key or call_key not in current_tool_calls:
+                    continue
+                call_data = current_tool_calls[call_key]
+                delta_part = _reconcile(call_data, final_args)
+                if delta_part is not None:
+                    yield delta_part
 
             elif event_type in {"response.completed", "response.done", "response.incomplete"}:
                 response_obj = event.get("response")
                 if isinstance(response_obj, dict):
                     self._apply_response_metadata(response_obj, llm_stream)
-                    stop_reason = self._map_stop_reason(response_obj.get("status"))
+                    stop_reason = self._map_stop_reason(response_obj)
                     if current_tool_calls and stop_reason == StopReason.STOP:
                         stop_reason = StopReason.TOOL_USE
                     yield StreamDone(stop_reason=stop_reason)
@@ -324,14 +389,14 @@ class OpenAICodexResponsesProvider(BaseProvider):
         if isinstance(usage, dict):
             input_details = usage.get("input_tokens_details")
             cached = 0
-            cache_write = int(usage.get("cache_write_tokens") or 0)
+            cache_write_value = usage.get("cache_write_tokens")
             if isinstance(input_details, dict):
                 cached = int(input_details.get("cached_tokens") or 0)
-                cache_write = int(
-                    input_details.get("cache_write_tokens")
-                    or input_details.get("cache_creation_tokens")
-                    or cache_write
-                )
+                if "cache_write_tokens" in input_details:
+                    cache_write_value = input_details["cache_write_tokens"]
+                elif "cache_creation_tokens" in input_details:
+                    cache_write_value = input_details["cache_creation_tokens"]
+            cache_write = int(cache_write_value) if cache_write_value is not None else 0
             input_tokens = int(usage.get("input_tokens") or 0)
             non_cached_input = max(input_tokens - cached, 0)
             llm_stream._usage = Usage(
@@ -348,7 +413,9 @@ class OpenAICodexResponsesProvider(BaseProvider):
         self, body: dict[str, Any], headers: dict[str, str]
     ) -> AsyncIterator[dict[str, Any]]:
         last_error: str | None = None
-        timeout = aiohttp.ClientTimeout(total=kon_config.llm.request_timeout_seconds)
+        timeout = aiohttp.ClientTimeout(
+            sock_connect=_CONNECT_TIMEOUT_SECONDS, sock_read=kon_config.llm.request_timeout_seconds
+        )
         async with aiohttp.ClientSession(timeout=timeout) as session:
             response: aiohttp.ClientResponse | None = None
             for attempt in range(_MAX_RETRIES + 1):
@@ -361,7 +428,7 @@ class OpenAICodexResponsesProvider(BaseProvider):
                     delay = _BASE_DELAY_MS * (2**attempt) / 1000
                     await asyncio.sleep(delay)
                     continue
-                raise CodexNonTransportError(last_error)
+                raise CodexNonTransportError(last_error, status=response.status)
 
             if response is None or response.status >= 400:
                 raise CodexNonTransportError(last_error or "Codex request failed after retries")
@@ -372,10 +439,15 @@ class OpenAICodexResponsesProvider(BaseProvider):
     async def _stream_websocket_events(
         self, body: dict[str, Any], headers: dict[str, str]
     ) -> AsyncIterator[dict[str, Any]]:
-        timeout = aiohttp.ClientTimeout(total=kon_config.llm.request_timeout_seconds)
+        timeout = aiohttp.ClientTimeout(
+            sock_connect=_CONNECT_TIMEOUT_SECONDS, sock_read=kon_config.llm.request_timeout_seconds
+        )
+        ws_timeout = aiohttp.ClientWSTimeout(ws_receive=kon_config.llm.request_timeout_seconds)  # type: ignore[call-arg]
         async with (
             aiohttp.ClientSession(timeout=timeout) as session,
-            session.ws_connect(self._resolve_websocket_url(), headers=headers) as ws,
+            session.ws_connect(
+                self._resolve_websocket_url(), headers=headers, heartbeat=20, timeout=ws_timeout
+            ) as ws,
         ):
             await ws.send_json({"type": "response.create", **body})
             saw_completion = False
@@ -405,12 +477,6 @@ class OpenAICodexResponsesProvider(BaseProvider):
                 elif msg.type == aiohttp.WSMsgType.ERROR:
                     error = ws.exception()
                     raise CodexTransportError(str(error) if error else "WebSocket error")
-                elif msg.type in {
-                    aiohttp.WSMsgType.CLOSE,
-                    aiohttp.WSMsgType.CLOSED,
-                    aiohttp.WSMsgType.CLOSING,
-                }:
-                    break
 
             if not saw_completion:
                 raise CodexTransportError("WebSocket stream closed before response.completed")
@@ -436,15 +502,23 @@ class OpenAICodexResponsesProvider(BaseProvider):
                 if isinstance(parsed, dict):
                     yield parsed
 
-    def _map_stop_reason(self, status: Any) -> StopReason:
+    def _map_stop_reason(self, response_obj: dict[str, Any]) -> StopReason:
+        status = response_obj.get("status")
         if status == "completed":
             return StopReason.STOP
         if status == "incomplete":
+            details = response_obj.get("incomplete_details")
+            reason = details.get("reason") if isinstance(details, dict) else None
+            if reason == "content_filter":
+                return StopReason.ERROR
             return StopReason.LENGTH
         if status in {"failed", "cancelled"}:
             return StopReason.ERROR
         return StopReason.STOP
 
     def should_retry_for_error(self, error: Exception) -> bool:
-        msg = str(error).lower()
-        return any(kw in msg for kw in ("429", "rate_limit", "server_error", "502", "503", "504"))
+        if isinstance(error, CodexTransportError):
+            return True
+        if isinstance(error, CodexNonTransportError) and error.status is not None:
+            return _is_retryable_status(error.status)
+        return False

--- a/src/kon/turn.py
+++ b/src/kon/turn.py
@@ -304,18 +304,17 @@ async def run_single_turn(
 
     # Collect tool calls during streaming, execute after stream completes
     pending_tool_calls: list[dict] = []
-    current_tool_call: dict | None = None
+    active_tool_calls: dict[int, dict] = {}
 
     # Token counting for tool argument streaming
-    _tool_arg_chunk_counter = 0
-    _tool_arg_token_count = 0
+    tool_arg_counters: dict[int, tuple[int, int]] = {}
 
     current_state: StreamState | None = None
     stop_reason: StopReason = StopReason.STOP
     interrupted = False
 
     def _finalize_current_state(include_empty: bool = True) -> list[StreamEvent]:
-        nonlocal current_state, current_tool_call, think_buffer, think_signature, text_buffer
+        nonlocal current_state, think_buffer, think_signature, text_buffer
 
         events: list[StreamEvent] = []
 
@@ -332,9 +331,10 @@ async def run_single_turn(
                 content.append(TextContent(text=full_text))
                 events.append(TextEndEvent(text=full_text))
             text_buffer = []
-        elif current_state == StreamState.TOOL_CALL and current_tool_call:
-            pending_tool_calls.append(current_tool_call)
-            current_tool_call = None
+        elif current_state == StreamState.TOOL_CALL and active_tool_calls:
+            pending_tool_calls.extend(active_tool_calls.values())
+            active_tool_calls.clear()
+            tool_arg_counters.clear()
 
         current_state = None
         return events
@@ -461,18 +461,11 @@ async def run_single_turn(
 
                 yield TextDeltaEvent(delta=t)
 
-            case ToolCallStart(id=id, name=name, arguments=initial_arguments):
+            case ToolCallStart(id=id, name=name, index=index, arguments=initial_arguments):
                 tool_call_count += 1
                 if current_state and current_state != StreamState.TOOL_CALL:
                     for finalize_event in _finalize_current_state():
                         yield finalize_event
-                elif current_state == StreamState.TOOL_CALL and current_tool_call:
-                    pending_tool_calls.append(current_tool_call)
-                    current_tool_call = None
-
-                # Reset token counters when starting a new tool call
-                _tool_arg_chunk_counter = 0
-                _tool_arg_token_count = 0
 
                 initial_arguments_json = ""
                 if initial_arguments:
@@ -482,7 +475,7 @@ async def run_single_turn(
                         initial_arguments_json = ""
 
                 current_state = StreamState.TOOL_CALL
-                current_tool_call = {
+                active_tool_calls[index] = {
                     "id": id,
                     "name": name,
                     "arguments": initial_arguments_json,
@@ -491,23 +484,30 @@ async def run_single_turn(
 
                 yield ToolStartEvent(tool_call_id=id, tool_name=name)
 
-            case ToolCallDelta(arguments_delta=delta):
-                if current_tool_call:
-                    current_tool_call["arguments"] += delta
-                    yield ToolArgsDeltaEvent(tool_call_id=current_tool_call["id"], delta=delta)
+            case ToolCallDelta(index=index, arguments_delta=delta, replace=replace):
+                tool_call = active_tool_calls.get(index)
+                if tool_call:
+                    if replace:
+                        tool_call["arguments"] = delta
+                        chunk_count, token_count = 0, 0
+                    else:
+                        tool_call["arguments"] += delta
+                        chunk_count, token_count = tool_arg_counters.get(index, (0, 0))
+                    yield ToolArgsDeltaEvent(tool_call_id=tool_call["id"], delta=delta)
 
                     # Count tokens and fire update event every Nth chunk after threshold tokens
-                    _tool_arg_chunk_counter += 1
-                    _tool_arg_token_count += _count_tokens(delta)
+                    chunk_count += 1
+                    token_count += _count_tokens(delta)
+                    tool_arg_counters[index] = (chunk_count, token_count)
 
                     if (
-                        _tool_arg_token_count > _TOOL_ARGS_TOKEN_DISPLAY_THRESHOLD
-                        and _tool_arg_chunk_counter % _TOOL_ARGS_TOKEN_CHUNK_UPDATE_INTERVAL == 0
+                        token_count > _TOOL_ARGS_TOKEN_DISPLAY_THRESHOLD
+                        and chunk_count % _TOOL_ARGS_TOKEN_CHUNK_UPDATE_INTERVAL == 0
                     ):
                         yield ToolArgsTokenUpdateEvent(
-                            tool_call_id=current_tool_call["id"],
-                            tool_name=current_tool_call["name"],
-                            token_count=_tool_arg_token_count,
+                            tool_call_id=tool_call["id"],
+                            tool_name=tool_call["name"],
+                            token_count=token_count,
                         )
 
             case StreamDone(stop_reason=reason):

--- a/tests/llm/test_openai_codex_provider_errors.py
+++ b/tests/llm/test_openai_codex_provider_errors.py
@@ -1,6 +1,16 @@
+from collections.abc import AsyncIterator
+from typing import Any
+
 import pytest
 
-from kon.core.types import StreamDone, TextPart
+from kon.core.types import (
+    StopReason,
+    StreamDone,
+    StreamError,
+    TextPart,
+    ToolCallDelta,
+    ToolCallStart,
+)
 from kon.llm.base import LLMStream, ProviderConfig
 from kon.llm.providers.openai_codex_responses import (
     _WS_FALLBACK_SESSIONS,
@@ -8,6 +18,18 @@ from kon.llm.providers.openai_codex_responses import (
     OpenAICodexResponsesProvider,
     _format_provider_error,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_ws_fallback_sessions():
+    _WS_FALLBACK_SESSIONS.clear()
+    yield
+    _WS_FALLBACK_SESSIONS.clear()
+
+
+async def _async_iter(events: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for event in events:
+        yield event
 
 
 def test_format_provider_error_preserves_non_empty_message():
@@ -46,7 +68,6 @@ async def test_stream_falls_back_to_sse_when_websocket_fails_before_events(monke
     provider = OpenAICodexResponsesProvider(
         ProviderConfig(session_id="session-fallback", model="gpt-5.4")
     )
-    _WS_FALLBACK_SESSIONS.discard("session-fallback")
 
     async def fail_websocket(*args, **kwargs):
         raise CodexTransportError("websocket unavailable")
@@ -77,3 +98,242 @@ async def test_stream_falls_back_to_sse_when_websocket_fails_before_events(monke
     assert parts[0].text == "ok"
     assert isinstance(parts[1], StreamDone)
     assert "session-fallback" in _WS_FALLBACK_SESSIONS
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_stream_error_and_skips_fallback_on_mid_stream_ws_failure(monkeypatch):
+    provider = OpenAICodexResponsesProvider(
+        ProviderConfig(session_id="session-mid", model="gpt-5.4")
+    )
+
+    async def ws_events(*args, **kwargs):
+        yield {"type": "response.output_text.delta", "delta": "hi"}
+        raise CodexTransportError("late failure")
+
+    sse_calls: list[int] = []
+
+    async def sse_events(*args, **kwargs):
+        sse_calls.append(1)
+        if False:
+            yield
+
+    monkeypatch.setattr(provider, "_stream_websocket_events", ws_events)
+    monkeypatch.setattr(provider, "_stream_sse_events", sse_events)
+
+    parts = [
+        part
+        async for part in provider._stream_codex(
+            token="t",
+            account_id="a",
+            messages=[],
+            system_prompt=None,
+            tools=None,
+            temperature=None,
+            max_tokens=None,
+            llm_stream=LLMStream(),
+        )
+    ]
+
+    assert len(parts) == 2
+    assert isinstance(parts[0], TextPart)
+    assert parts[0].text == "hi"
+    assert isinstance(parts[1], StreamError)
+    assert "late failure" in parts[1].error
+    assert sse_calls == []
+    assert "session-mid" not in _WS_FALLBACK_SESSIONS
+
+
+@pytest.mark.asyncio
+async def test_process_codex_events_routes_parallel_function_call_deltas_by_item_id():
+    events: list[dict[str, Any]] = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_A",
+                "call_id": "call_A",
+                "name": "tool_a",
+            },
+        },
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_B",
+                "call_id": "call_B",
+                "name": "tool_b",
+            },
+        },
+        {"type": "response.function_call_arguments.delta", "item_id": "item_A", "delta": "{"},
+        {"type": "response.function_call_arguments.delta", "item_id": "item_B", "delta": "{"},
+        {"type": "response.function_call_arguments.delta", "item_id": "unknown", "delta": "BAD"},
+        {"type": "response.function_call_arguments.delta", "item_id": "item_A", "delta": '"x":1}'},
+        {"type": "response.function_call_arguments.delta", "item_id": "item_B", "delta": '"y":2}'},
+        {"type": "response.completed", "response": {"status": "completed"}},
+    ]
+
+    provider = OpenAICodexResponsesProvider(ProviderConfig(model="gpt-5.4"))
+    parts = [p async for p in provider._process_codex_events(_async_iter(events), LLMStream())]
+
+    starts = [p for p in parts if isinstance(p, ToolCallStart)]
+    deltas = [p for p in parts if isinstance(p, ToolCallDelta)]
+    done = [p for p in parts if isinstance(p, StreamDone)]
+
+    assert len(starts) == 2
+    assert starts[0].index == 0 and starts[0].name == "tool_a"
+    assert starts[1].index == 1 and starts[1].name == "tool_b"
+
+    assert len(deltas) == 4
+    a_args = "".join(d.arguments_delta for d in deltas if d.index == 0)
+    b_args = "".join(d.arguments_delta for d in deltas if d.index == 1)
+    assert a_args == '{"x":1}'
+    assert b_args == '{"y":2}'
+
+    assert len(done) == 1
+    assert done[0].stop_reason == StopReason.TOOL_USE
+
+
+@pytest.mark.asyncio
+async def test_process_codex_events_done_reconciliation_appends_missing_suffix():
+    events: list[dict[str, Any]] = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_A",
+                "call_id": "call_A",
+                "name": "tool_a",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_A",
+            "delta": '{"cmd":"ec',
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item_A",
+            "arguments": '{"cmd":"echo"}',
+        },
+        {"type": "response.completed", "response": {"status": "completed"}},
+    ]
+
+    provider = OpenAICodexResponsesProvider(ProviderConfig(model="gpt-5.4"))
+    parts = [p async for p in provider._process_codex_events(_async_iter(events), LLMStream())]
+    deltas = [p for p in parts if isinstance(p, ToolCallDelta)]
+
+    assert len(deltas) == 2
+    assert deltas[0].arguments_delta == '{"cmd":"ec'
+    assert deltas[1].arguments_delta == 'ho"}'
+
+
+@pytest.mark.asyncio
+async def test_process_codex_events_output_item_done_reconciles_from_initial_arguments():
+    events: list[dict[str, Any]] = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_A",
+                "call_id": "call_A",
+                "name": "tool_a",
+                "arguments": '{"path":',
+            },
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "id": "item_A",
+                "call_id": "call_A",
+                "name": "tool_a",
+                "arguments": '{"path":"/tmp"}',
+            },
+        },
+        {"type": "response.completed", "response": {"status": "completed"}},
+    ]
+
+    provider = OpenAICodexResponsesProvider(ProviderConfig(model="gpt-5.4"))
+    parts = [p async for p in provider._process_codex_events(_async_iter(events), LLMStream())]
+    deltas = [p for p in parts if isinstance(p, ToolCallDelta)]
+
+    assert len(deltas) == 2
+    assert [d.index for d in deltas] == [0, 0]
+    assert [d.replace for d in deltas] == [False, False]
+    assert "".join(d.arguments_delta for d in deltas) == '{"path":"/tmp"}'
+
+
+@pytest.mark.asyncio
+async def test_process_codex_events_final_arguments_can_replace_partial_arguments():
+    events: list[dict[str, Any]] = [
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_A",
+                "call_id": "call_A",
+                "name": "tool_a",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_A",
+            "delta": '{"broken":',
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item_A",
+            "arguments": '{"path":"/tmp"}',
+        },
+        {"type": "response.completed", "response": {"status": "completed"}},
+    ]
+
+    provider = OpenAICodexResponsesProvider(ProviderConfig(model="gpt-5.4"))
+    parts = [p async for p in provider._process_codex_events(_async_iter(events), LLMStream())]
+    deltas = [p for p in parts if isinstance(p, ToolCallDelta)]
+
+    assert len(deltas) == 2
+    assert deltas[0].arguments_delta == '{"broken":'
+    assert deltas[0].replace is False
+    assert deltas[1].arguments_delta == '{"path":"/tmp"}'
+    assert deltas[1].replace is True
+
+
+@pytest.mark.asyncio
+async def test_incomplete_response_with_content_filter_maps_to_stop_reason_error():
+    events: list[dict[str, Any]] = [
+        {
+            "type": "response.incomplete",
+            "response": {
+                "status": "incomplete",
+                "incomplete_details": {"reason": "content_filter"},
+            },
+        }
+    ]
+
+    provider = OpenAICodexResponsesProvider(ProviderConfig(model="gpt-5.4"))
+    parts = [p async for p in provider._process_codex_events(_async_iter(events), LLMStream())]
+    done = [p for p in parts if isinstance(p, StreamDone)]
+
+    assert len(done) == 1
+    assert done[0].stop_reason == StopReason.ERROR
+
+
+def test_apply_response_metadata_preserves_zero_cache_write_tokens():
+    provider = OpenAICodexResponsesProvider(ProviderConfig(model="gpt-5.4"))
+    llm_stream = LLMStream()
+    response_obj = {
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 7,
+            "input_tokens_details": {
+                "cached_tokens": 0,
+                "cache_write_tokens": 0,
+                "cache_creation_tokens": 9,
+            },
+        }
+    }
+    provider._apply_response_metadata(response_obj, llm_stream)
+    assert llm_stream._usage is not None
+    assert llm_stream._usage.cache_write_tokens == 0

--- a/tests/llm/test_openai_codex_provider_errors.py
+++ b/tests/llm/test_openai_codex_provider_errors.py
@@ -144,6 +144,38 @@ async def test_stream_emits_stream_error_and_skips_fallback_on_mid_stream_ws_fai
 
 
 @pytest.mark.asyncio
+async def test_stream_propagates_non_codex_exception_from_websocket_setup(monkeypatch):
+    provider = OpenAICodexResponsesProvider(
+        ProviderConfig(session_id="session-bug", model="gpt-5.4")
+    )
+
+    async def buggy_websocket(*args, **kwargs):
+        raise KeyError("oops")
+        yield
+
+    def sse_events(*args, **kwargs):
+        pytest.fail("SSE fallback should not be invoked")
+
+    monkeypatch.setattr(provider, "_stream_websocket_events", buggy_websocket)
+    monkeypatch.setattr(provider, "_stream_sse_events", sse_events)
+
+    with pytest.raises(KeyError, match="oops"):
+        async for _ in provider._stream_codex(
+            token="t",
+            account_id="a",
+            messages=[],
+            system_prompt=None,
+            tools=None,
+            temperature=None,
+            max_tokens=None,
+            llm_stream=LLMStream(),
+        ):
+            pass
+
+    assert "session-bug" not in _WS_FALLBACK_SESSIONS
+
+
+@pytest.mark.asyncio
 async def test_process_codex_events_routes_parallel_function_call_deltas_by_item_id():
     events: list[dict[str, Any]] = [
         {

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -1,9 +1,21 @@
 import asyncio
+from collections.abc import AsyncIterator
 
 import pytest
 
 from kon import Config, reset_config, set_config
-from kon.core.types import StopReason, TextContent, UserMessage
+from kon.core.types import (
+    Message,
+    StopReason,
+    StreamDone,
+    StreamPart,
+    TextContent,
+    ToolCall,
+    ToolCallDelta,
+    ToolCallStart,
+    ToolDefinition,
+    UserMessage,
+)
 from kon.events import (
     AgentEndEvent,
     AgentStartEvent,
@@ -16,6 +28,7 @@ from kon.events import (
     ThinkingDeltaEvent,
     ThinkingEndEvent,
     ThinkingStartEvent,
+    ToolArgsDeltaEvent,
     ToolArgsTokenUpdateEvent,
     ToolEndEvent,
     ToolResultEvent,
@@ -24,6 +37,7 @@ from kon.events import (
     TurnStartEvent,
     WarningEvent,
 )
+from kon.llm.base import BaseProvider, LLMStream, ProviderConfig
 from kon.llm.providers.mock import MockProvider
 from kon.loop import Agent
 from kon.session import Session
@@ -44,6 +58,34 @@ def in_memory_session():
 @pytest.fixture
 def sample_messages():
     return [UserMessage(content="Test query")]
+
+
+class StreamPartsProvider(BaseProvider):
+    name = "stream-parts"
+
+    def __init__(self, parts: list[StreamPart]):
+        super().__init__(ProviderConfig(model="stream-parts"))
+        self._parts = parts
+
+    async def _stream_impl(
+        self,
+        messages: list[Message],
+        *,
+        system_prompt: str | None = None,
+        tools: list[ToolDefinition] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> LLMStream:
+        async def iterator() -> AsyncIterator[StreamPart]:
+            for part in self._parts:
+                yield part
+
+        stream = LLMStream()
+        stream.set_iterator(iterator())
+        return stream
+
+    def should_retry_for_error(self, error: Exception) -> bool:
+        return False
 
 
 @pytest.fixture
@@ -489,6 +531,37 @@ async def test_run_single_turn_unknown_tool_scenario(sample_messages, tools):
     content = tool_result.result.content[0]
     assert isinstance(content, TextContent)
     assert "Unknown tool" in content.text
+
+
+@pytest.mark.asyncio
+async def test_run_single_turn_routes_indexed_tool_call_deltas(sample_messages):
+    provider = StreamPartsProvider(
+        [
+            ToolCallStart(id="call_A", name="unknown_a", index=0),
+            ToolCallStart(id="call_B", name="unknown_b", index=1),
+            ToolCallDelta(index=0, arguments_delta='{"bad":'),
+            ToolCallDelta(index=1, arguments_delta='{"y": 2}'),
+            ToolCallDelta(index=0, arguments_delta='{"x": 1}', replace=True),
+            StreamDone(stop_reason=StopReason.TOOL_USE),
+        ]
+    )
+    events = []
+
+    async for event in run_single_turn(provider, sample_messages, [], turn=1):
+        events.append(event)
+
+    arg_deltas = [e for e in events if isinstance(e, ToolArgsDeltaEvent)]
+    assert [e.tool_call_id for e in arg_deltas] == ["call_A", "call_B", "call_A"]
+
+    turn_end = next(e for e in events if isinstance(e, TurnEndEvent))
+    assert turn_end.assistant_message is not None
+    tool_calls = [
+        part for part in turn_end.assistant_message.content if isinstance(part, ToolCall)
+    ]
+    assert [(call.id, call.arguments) for call in tool_calls] == [
+        ("call_A", {"x": 1}),
+        ("call_B", {"y": 2}),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

There were a few issues with how the OpenAI Codex Responses provider handles streamed function calls that I addressed (some of which were introduced [here](https://github.com/0xku/kon/commit/67c17df) and some of which were pre-existing).

When the model returned more than one function call in a turn, argument deltas were routed to whichever tool call was added most recently rather than the call the event was for. The second call's deltas would land in the first call's accumulator, leaving at least one of the tools with broken JSON. Routing now uses the event's `item_id` when present, otherwise falling back to the most recent call.

The previous code also ignored both [.done events](https://developers.openai.com/api/reference/resources/responses/streaming-events) for function arguments, which carry the server's final string. When the streamed deltas drifted from it, the assistant message would ship the broken accumulator. A new reconcile step runs on the `.done` events and brings the accumulator in line with the server, either appending what's missing or replacing it outright when they diverge. That second case is a new flag on `ToolCallDelta` that tells `turn.py` to reset that tool call's accumulator and token counters.

Inside `run_single_turn`, the single `current_tool_call` reference could only hold one call at a time, so the same routing issue applied. I switched it to a dict keyed by the stream's tool call index.

## Other bug fixes

- Retry decisions were based on looking for `429` or similar in the error message, which would silently break if the format changed. They now branch on exception type and HTTP status.
- A single `total=` timeout would cut off long Codex responses partway through. Timeouts now use `sock_connect` plus `sock_read` so the budget applies to inactivity rather than total wall time, and the websocket gets a heartbeat.
- A blanket `except Exception` around the websocket call was swallowing programmer mistakes and silently falling back to SSE, so I narrowed it to transport errors so real bugs surface.
- Content filter refusals were showing up as length cutoffs. `incomplete` responses with reason `content_filter` now map to `ERROR` instead of `LENGTH`.
- A literal `0` for cache write tokens was getting collapsed by an `or` chain in the usage parser, which I replaced with a presence check.
