### PR TITLE
fix: initialize tool expansion before mount

### DIFF
--- a/src/kon/ui/blocks.py
+++ b/src/kon/ui/blocks.py
@@ -194,7 +194,12 @@ class ToolBlock(Static):
     MAX_HEADER_LINES = 2
 
     def __init__(
-        self, name: str = "", call_msg: str | None = None, icon: str = "→", **kwargs
+        self,
+        name: str = "",
+        call_msg: str | None = None,
+        icon: str = "→",
+        expanded: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._name = name
@@ -204,7 +209,7 @@ class ToolBlock(Static):
         self._ui_details: str | None = None
         self._ui_details_full: str | None = None
         self._result_markup: bool = True
-        self._expanded: bool = False
+        self._expanded: bool = expanded
         self._success: bool | None = None
         self._awaiting_approval: bool = False
         self._approval_preview: str | None = None

--- a/src/kon/ui/chat.py
+++ b/src/kon/ui/chat.py
@@ -444,8 +444,9 @@ class ChatLog(VerticalScroll):
     def start_tool(
         self, name: str, tool_id: str, call_msg: str | None = None, icon: str = "→"
     ) -> ToolBlock:
-        block = ToolBlock(name=name, call_msg=call_msg, icon=icon)
-        block.set_expanded(self._tool_output_expanded)
+        block = ToolBlock(
+            name=name, call_msg=call_msg, icon=icon, expanded=self._tool_output_expanded
+        )
 
         # Consecutive tool calls without detail output render compactly (no
         # margin). Tools with detail output (diffs, bash output, etc.) always

--- a/tests/ui/test_tool_output_expansion.py
+++ b/tests/ui/test_tool_output_expansion.py
@@ -1,8 +1,16 @@
+import pytest
 from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import Label
 
 from kon.ui.blocks import ToolBlock
 from kon.ui.chat import ChatLog
 from kon.ui.tool_output import format_expand_hint, truncate_tool_output_text
+
+
+class ToolExpansionTestApp(App):
+    def compose(self) -> ComposeResult:
+        yield ChatLog(id="chat-log")
 
 
 def test_format_expand_hint_styles_ctrl_o_differently():
@@ -44,3 +52,16 @@ def test_chat_log_toggles_all_tool_blocks(monkeypatch):
 
     assert chat.toggle_tool_output_expanded() is False
     assert seen == {"a": False, "b": False}
+
+
+@pytest.mark.asyncio
+async def test_start_tool_uses_expanded_state_before_mount():
+    async with ToolExpansionTestApp().run_test() as pilot:
+        chat = pilot.app.query_one("#chat-log", ChatLog)
+        chat.set_tool_output_expanded(True)
+
+        block = chat.start_tool("bash", "tool-1")
+        await pilot.pause()
+
+        assert block._expanded is True
+        assert block.query_one("#tool-output", Label)


### PR DESCRIPTION
## Summary
- initialize new tool blocks with the current output expansion state before they are mounted
- avoid calling set_expanded before ToolBlock.compose() creates #tool-output
- add regression coverage for starting a tool after output expansion has already been enabled

## Tests
- uv run ruff format .
- uv run ruff check .
- uv run python -m pyright .
- uv run python -m pytest