### PR TITLE
Textual-image Warning on Windows

### DIFF
--- a/src/kon/ui/blocks.py
+++ b/src/kon/ui/blocks.py
@@ -485,13 +485,14 @@ class ToolBlock(Static):
             output.add_class("-hidden")
 
     def _render_images(self) -> None:
-        from textual_image.widget import Image as TextualImage
         container = self.query_one("#tool-images", Static)
         container.remove_children()
 
         if not self._images:
             container.add_class("-hidden")
             return
+
+        from textual_image.widget import Image as TextualImage
 
         self.remove_class("-compact")
         self.add_class("-with-details")

--- a/src/kon/ui/blocks.py
+++ b/src/kon/ui/blocks.py
@@ -8,7 +8,6 @@ from textual import events
 from textual.app import ComposeResult
 from textual.message import Message
 from textual.widgets import Label, Static
-from textual_image.widget import Image as TextualImage
 
 from kon import config
 from kon.core.types import ImageContent
@@ -486,6 +485,7 @@ class ToolBlock(Static):
             output.add_class("-hidden")
 
     def _render_images(self) -> None:
+        from textual_image.widget import Image as TextualImage
         container = self.query_one("#tool-images", Static)
         container.remove_children()
 


### PR DESCRIPTION

<img width="1314" height="575" alt="image001" src="https://github.com/user-attachments/assets/f57aa2e6-d3ea-46dc-b353-10f963e7045b" />

 
## Issue Description
 
When launching Kon on Windows, the following warning appears:
 
```
Failed to get cell size via escape sequence, assuming VT340 sizes
Traceback (most recent call last):
  File "d:\.venvllm\Lib\site-packages\textual_image\_terminal.py", line 65, in get_cell_size
    with capture_terminal_response("\x1b[", "t", 0.1) as response:
  File "D:\Miniconda3\py312_24.3.0-0-Windows-x86_64\Lib\contextlib.py", line 144, in __exit__
    next(self.gen)
  File "d:\.venvllm\Lib\site-packages\textual_image\_win32.py", line 128, in capture_terminal_response
    response.sequence += read(stdin, 1, timeout)
  File "d:\.venvllm\Lib\site-packages\textual_image\_win32.py", line 27, in read
    wait_for_object(fd, timeout)
  File "d:\.venvllm\Lib\site-packages\textual_image\_win32.py", line 52, in wait_for_object
    raise TimeoutError("Timeout waiting for data")
```
 
## Root Cause
 
The warning is triggered by the `textual-image` package (version 0.12.0), which is a transitive dependency of `textual` (line 34 in `pyproject.toml`):
 
```python
"textual-image[textual]>=0.12.0"
```
 
### How it happens:
 
1. When Kon is launched, `textual_image.widget.__init__.py` is imported
2. This file calls `get_cell_size()` at import time (line 20) to fill a cache
3. On Windows, `get_cell_size()` in `textual_image/_terminal.py` tries to:
   - First try ioctl (`get_tiocgwinsz()`) - fails on some terminals
   - Then falls back to an escape sequence (`\x1b[16t`) to query cell size
   - The escape sequence uses `capture_terminal_response()` which times out on Windows
4. The timeout triggers the warning and exception
 
### File locations:
 
- `textual_image/widget/__init__.py` - calls `get_cell_size()` at import time
- `textual_image/_terminal.py` - contains `get_cell_size()` function
- `textual_image/_win32.py` - Windows-specific terminal I/O functions
- `kon/ui/blocks.py` - uses `TextualImage` from `textual_image.widget` (line 11)
 
## Solution
Moved the import line inside _render_images()  where its used.