### PR TITLE
fix: hide info bar during completion popup

### DIFF
--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -60,7 +60,7 @@ from .autocomplete import DEFAULT_COMMANDS, FilePathProvider, SlashCommand, Slas
 from .blocks import HandoffLinkBlock, LaunchWarning
 from .chat import ChatLog
 from .commands import CommandsMixin
-from .floating_list import FloatingList
+from .floating_list import FloatingList, ListItem
 from .input import InputBox
 from .selection_mode import SelectionMode
 from .session_ui import SessionUIMixin
@@ -214,7 +214,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         yield QueueDisplay(id="queue-display")
         yield StatusLine(id="status-line")
         yield InputBox(cwd=self._cwd, id="input-box")
-        yield FloatingList(window_size=8, label_width=12, id="completion-list")
+        yield FloatingList(window_size=10, label_width=12, id="completion-list")
         yield TreeSelector(id="tree-selector")
         yield InfoBar(
             cwd=self._cwd,
@@ -504,6 +504,33 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
             chat = self.query_one("#chat-log", ChatLog)
             chat.scroll_end(animate=False)
 
+    def _restore_chat_scroll_after_refresh(self, was_at_bottom: bool) -> None:
+        self.call_after_refresh(lambda: self._restore_chat_scroll_if_needed(was_at_bottom))
+
+    def _set_bottom_info_displaced(self, displaced: bool) -> None:
+        info_bar = self.query_one("#info-bar", InfoBar)
+        if displaced:
+            info_bar.add_class("-completion-hidden")
+        else:
+            info_bar.remove_class("-completion-hidden")
+
+    def _show_completion_list(
+        self,
+        items: list[ListItem],
+        *,
+        searchable: bool = False,
+        max_label_width: int | None = None,
+    ) -> None:
+        completion_list = self.query_one("#completion-list", FloatingList)
+        self._set_bottom_info_displaced(True)
+        completion_list.show(items, searchable=searchable, max_label_width=max_label_width)
+
+    def _hide_completion_list(self, *, restore_info_bar: bool = True) -> None:
+        completion_list = self.query_one("#completion-list", FloatingList)
+        completion_list.hide()
+        if restore_info_bar:
+            self._set_bottom_info_displaced(False)
+
     @on(InputBox.CompletionUpdate)
     def on_completion_update(self, event: InputBox.CompletionUpdate) -> None:
         if self._selection_mode is not None:
@@ -512,35 +539,38 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         completion_list = self.query_one("#completion-list", FloatingList)
         was_at_bottom = self._is_chat_at_bottom()
         if completion_list.is_visible:
+            self._set_bottom_info_displaced(True)
             completion_list.update_items(event.items)
         else:
-            completion_list.show(event.items)
-        self.call_after_refresh(lambda: self._restore_chat_scroll_if_needed(was_at_bottom))
+            self._show_completion_list(event.items)
+        self._restore_chat_scroll_after_refresh(was_at_bottom)
 
     @on(InputBox.CompletionHide)
     def on_completion_hide(self, event: InputBox.CompletionHide) -> None:
-        completion_list = self.query_one("#completion-list", FloatingList)
         input_box = self.query_one("#input-box", InputBox)
         was_at_bottom = self._is_chat_at_bottom()
 
         with self.batch_update():
-            completion_list.hide()
-
             if self._selection_mode is not None:
                 # If we were in a sub-picker from settings, go back to settings
                 if self._settings_active:
+                    self._hide_completion_list(restore_info_bar=False)
                     self._settings_active = False
                     self._show_settings_picker()
+                    self._restore_chat_scroll_after_refresh(was_at_bottom)
                     return
 
+                self._hide_completion_list()
                 self._selection_mode = None
                 input_box.clear()
                 input_box.set_autocomplete_enabled(True)
                 self._reset_ctrl_d_delete_state()
+            else:
+                self._hide_completion_list()
 
             input_box.set_completing(False)
 
-        self.call_after_refresh(lambda: self._restore_chat_scroll_if_needed(was_at_bottom))
+        self._restore_chat_scroll_after_refresh(was_at_bottom)
 
     @on(InputBox.CompletionSelect)
     def on_completion_select(self, event: InputBox.CompletionSelect) -> None:
@@ -548,28 +578,40 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         if self._selection_mode == SelectionMode.TREE:
             self.query_one("#tree-selector", TreeSelector).action_select()
             return
+        was_at_bottom = self._is_chat_at_bottom()
         completion_list = self.query_one("#completion-list", FloatingList)
         item = completion_list.selected_item
 
         if not item:
-            completion_list.hide()
+            self._hide_completion_list()
             input_box.set_completing(False)
             input_box.submit_raw()
+            self._restore_chat_scroll_after_refresh(was_at_bottom)
             return
 
         if self._selection_mode is not None:
             selection_mode = self._selection_mode
+            keeps_info_bar_displaced = selection_mode == SelectionMode.SETTINGS or (
+                selection_mode in (SelectionMode.THEME, SelectionMode.THINKING)
+                and self._settings_active
+            )
             with self.batch_update():
-                completion_list.hide()
+                self._hide_completion_list(restore_info_bar=not keeps_info_bar_displaced)
                 self._selection_mode = None
                 input_box.clear()
                 input_box.set_autocomplete_enabled(True)
                 input_box.set_completing(False)
                 self._reset_ctrl_d_delete_state()
 
+            def show_settings_picker_and_restore() -> None:
+                self._show_settings_picker()
+                self._restore_chat_scroll_after_refresh(was_at_bottom)
+
             match selection_mode:
                 case SelectionMode.SETTINGS:
-                    self._handle_settings_select(item.value)
+                    settings_result = self._handle_settings_select(item.value)
+                    if settings_result == "closed":
+                        self._set_bottom_info_displaced(False)
                 case SelectionMode.SESSION:
                     self.run_worker(self._load_session(item.value.path), exclusive=True)
                 case SelectionMode.TREE:
@@ -580,14 +622,16 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
                     self._select_theme(item.value)
                     if self._settings_active:
                         self._settings_active = False
-                        self.call_later(self._show_settings_picker)
+                        self.call_later(show_settings_picker_and_restore)
+                        return
                 case SelectionMode.PERMISSIONS:
                     self._select_permission_mode(item.value)
                 case SelectionMode.THINKING:
                     self._select_thinking_level(item.value)
                     if self._settings_active:
                         self._settings_active = False
-                        self.call_later(self._show_settings_picker)
+                        self.call_later(show_settings_picker_and_restore)
+                        return
                 case SelectionMode.NOTIFICATIONS:
                     self._select_notifications_mode(item.value)
                 case SelectionMode.LOGIN:
@@ -595,15 +639,17 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
                 case SelectionMode.LOGOUT:
                     self._select_logout_provider(item.value)
 
+            self._restore_chat_scroll_after_refresh(was_at_bottom)
             return
 
         if input_box.is_tab_completing:
-            completion_list.hide()
+            self._hide_completion_list()
             input_box.apply_tab_path_completion(item)
+            self._restore_chat_scroll_after_refresh(was_at_bottom)
             return
 
         provider = input_box.active_provider
-        completion_list.hide()
+        self._hide_completion_list()
 
         if isinstance(provider, SlashCommandProvider):
             input_box.apply_slash_command(item)
@@ -611,6 +657,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
             input_box.apply_file_completion(item)
 
         input_box.set_completing(False)
+        self._restore_chat_scroll_after_refresh(was_at_bottom)
 
     @on(InputBox.SearchUpdate)
     def on_search_update(self, event: InputBox.SearchUpdate) -> None:

--- a/src/kon/ui/commands.py
+++ b/src/kon/ui/commands.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from kon import (
     config,
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 
 Choice = TypeVar("Choice", bound=str)
+SettingsSelectionResult = Literal["reopened-picker", "closed"]
 
 
 class CommandsMixin:
@@ -71,6 +72,16 @@ class CommandsMixin:
         def _render_session_entries(self, session: Session) -> None: ...
         def _apply_theme(self, theme_id: str) -> None: ...
         def _apply_thinking_level_style(self, level: str) -> None: ...
+        def _show_completion_list(
+            self,
+            items: list[ListItem],
+            *,
+            searchable: bool = False,
+            max_label_width: int | None = None,
+        ) -> None: ...
+        def _hide_completion_list(self, *, restore_info_bar: bool = True) -> None: ...
+        def _is_chat_at_bottom(self) -> bool: ...
+        def _restore_chat_scroll_after_refresh(self, was_at_bottom: bool) -> None: ...
 
     def _handle_command(self, text: str) -> bool:
         parts = text[1:].split(maxsplit=1)
@@ -159,21 +170,20 @@ class CommandsMixin:
         searchable: bool = True,
         max_label_width: int | None = None,
     ) -> None:
-        completion_list = self.query_one("#completion-list", FloatingList)
         input_box = self.query_one("#input-box", InputBox)
+        was_at_bottom = self._is_chat_at_bottom()
 
         with self.batch_update():  # type: ignore[attr-defined]
-            if max_label_width is None:
-                completion_list.show(items, searchable=searchable)
-            else:
-                completion_list.show(items, searchable=searchable, max_label_width=max_label_width)
-
+            self._show_completion_list(
+                items, searchable=searchable, max_label_width=max_label_width
+            )
             input_box.clear()
             input_box.set_autocomplete_enabled(False)
             input_box.set_completing(True)
             input_box.focus()
 
         self._selection_mode = selection_mode
+        self._restore_chat_scroll_after_refresh(was_at_bottom)
 
     def _build_choice_items(
         self, choices: Sequence[Choice], current: Choice, descriptions: Mapping[Choice, str]
@@ -374,7 +384,7 @@ class CommandsMixin:
     def _handle_settings_command(self) -> None:
         self._show_settings_picker()
 
-    def _handle_settings_select(self, item_value: str) -> None:
+    def _handle_settings_select(self, item_value: str) -> SettingsSelectionResult:
         if item_value == "notifications":
             current_enabled = config.notifications.enabled
             set_notifications_enabled(not current_enabled)
@@ -382,6 +392,7 @@ class CommandsMixin:
             chat = self.query_one("#chat-log", ChatLog)
             chat.show_status(f"Notifications turned {mode}")
             self._show_settings_picker(selected_value=item_value)
+            return "reopened-picker"
 
         elif item_value == "show-shortcuts":
             shortcuts_current = config.ui.show_welcome_shortcuts
@@ -390,6 +401,7 @@ class CommandsMixin:
             chat = self.query_one("#chat-log", ChatLog)
             chat.show_status(f"Welcome shortcuts turned {mode}")
             self._show_settings_picker(selected_value=item_value)
+            return "reopened-picker"
 
         elif item_value == "permissions":
             current: PermissionMode = config.permissions.mode
@@ -400,14 +412,22 @@ class CommandsMixin:
             chat = self.query_one("#chat-log", ChatLog)
             chat.show_status(f"Permission mode changed to {new_mode}")
             self._show_settings_picker(selected_value=item_value)
+            return "reopened-picker"
 
         elif item_value == "themes":
             self._settings_active = True
             self._handle_themes_command("")
+            return "reopened-picker"
 
         elif item_value == "thinking":
+            if self._runtime.provider is None:
+                self._handle_thinking_command("")
+                return "closed"
             self._settings_active = True
             self._handle_thinking_command("")
+            return "reopened-picker"
+
+        return "closed"
 
     def _select_theme(self, theme_id: str) -> None:
         set_theme(theme_id)
@@ -675,8 +695,9 @@ class CommandsMixin:
             return
 
         items = self._build_resume_items()
+        was_at_bottom = self._is_chat_at_bottom()
         if not items:
-            completion_list.hide()
+            self._hide_completion_list()
             input_box = self.query_one("#input-box", InputBox)
             input_box.set_autocomplete_enabled(True)
             input_box.set_completing(False)
@@ -687,10 +708,11 @@ class CommandsMixin:
                 timeout=2,
                 severity="information",
             )
-            return
+        else:
+            completion_list.update_items(items)
+            self.notify("Session deleted", title="Sessions", timeout=2, severity="information")
 
-        completion_list.update_items(items)
-        self.notify("Session deleted", title="Sessions", timeout=2, severity="information")
+        self._restore_chat_scroll_after_refresh(was_at_bottom)
 
     def _handle_login_command(self, args: str) -> None:
         providers = [

--- a/src/kon/ui/floating_list.py
+++ b/src/kon/ui/floating_list.py
@@ -82,6 +82,7 @@ class FloatingList[T](Widget):
         super().__init__(id=id, classes=classes)
         self._window_size = window_size
         self._min_label_width = label_width
+        self._default_max_label_width = max_label_width
         self._max_label_width = max_label_width
         self._label_width = label_width
         self._items: list[ListItem[T]] = []
@@ -162,8 +163,9 @@ class FloatingList[T](Widget):
         self._all_items = items if searchable else []
         self._items = items
         self._selected_index = 0
-        if max_label_width is not None:
-            self._max_label_width = max_label_width
+        self._max_label_width = (
+            max_label_width if max_label_width is not None else self._default_max_label_width
+        )
         self._description_width = self._compute_description_width()
         self._label_width = self._compute_label_width()
         self._visible = True

--- a/src/kon/ui/styles.py
+++ b/src/kon/ui/styles.py
@@ -288,6 +288,11 @@ Screen {{
     color: {colors.dim};
 }}
 
+.info-bar.-completion-hidden {{
+    display: none;
+    height: 0;
+}}
+
 #info-row-1, #info-row-2 {{
     height: 1;
 }}

--- a/tests/ui/test_completion_chrome.py
+++ b/tests/ui/test_completion_chrome.py
@@ -1,0 +1,486 @@
+from collections.abc import Callable
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+
+from kon.runtime import ConversationRuntime
+from kon.session import SessionInfo
+from kon.ui.app import Kon
+from kon.ui.autocomplete import FilePathProvider, SlashCommand, SlashCommandProvider
+from kon.ui.floating_list import FloatingList, ListItem
+from kon.ui.input import InputBox
+from kon.ui.selection_mode import SelectionMode
+
+
+class FakeChat:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.max_scroll_y = 0
+        self.scroll_y = 0
+        self.scrolled_to_end = False
+
+    def add_info_message(self, message: str, error: bool = False, warning: bool = False) -> None:
+        if error:
+            self.errors.append(message)
+
+    def scroll_end(self, animate: bool = False) -> None:
+        del animate
+        self.scrolled_to_end = True
+
+
+class FakeInfoBar:
+    def __init__(self) -> None:
+        self.classes: set[str] = set()
+        self.removed_classes: list[str] = []
+
+    def add_class(self, class_name: str) -> None:
+        self.classes.add(class_name)
+
+    def remove_class(self, class_name: str) -> None:
+        self.removed_classes.append(class_name)
+        self.classes.discard(class_name)
+
+    def set_permission_mode(self, mode: str) -> None:
+        pass
+
+
+class FakeCompletionList:
+    def __init__(
+        self, selected_item: ListItem | None = None, *, visible: bool | None = None
+    ) -> None:
+        self.items: list[ListItem] = []
+        self.selected_item = selected_item
+        self.searchable: bool | None = None
+        self.max_label_width: int | None = None
+        initially_visible = selected_item is not None if visible is None else visible
+        self.hidden = not initially_visible
+        self.updated_items: list[ListItem] | None = None
+
+    @property
+    def is_visible(self) -> bool:
+        return not self.hidden
+
+    def show(
+        self, items: list[ListItem], searchable: bool = False, max_label_width: int | None = None
+    ) -> None:
+        self.items = items
+        self.searchable = searchable
+        self.max_label_width = max_label_width
+        self.hidden = False
+        self.selected_item = items[0] if items else None
+
+    def update_items(self, items: list[ListItem]) -> None:
+        self.updated_items = items
+        self.items = items
+
+    def hide(self) -> None:
+        self.hidden = True
+
+    def select_value(self, value: object) -> None:
+        for item in self.items:
+            if item.value == value:
+                self.selected_item = item
+                return
+
+
+class FakeInputBox:
+    def __init__(self) -> None:
+        self.is_tab_completing = False
+        self.active_provider: SlashCommandProvider | FilePathProvider | None = None
+        self.completing: bool | None = None
+        self.submitted = False
+        self.tab_completed_items: list[ListItem] = []
+        self.slash_completed_items: list[ListItem] = []
+        self.file_completed_items: list[ListItem] = []
+        self.cleared = False
+        self.autocomplete_enabled: bool | None = None
+
+    def set_completing(self, completing: bool) -> None:
+        self.completing = completing
+
+    def submit_raw(self) -> None:
+        self.submitted = True
+
+    def apply_tab_path_completion(self, item: ListItem) -> None:
+        self.tab_completed_items.append(item)
+
+    def apply_slash_command(self, item: ListItem) -> None:
+        self.slash_completed_items.append(item)
+
+    def apply_file_completion(self, item: ListItem) -> None:
+        self.file_completed_items.append(item)
+
+    def clear(self) -> None:
+        self.cleared = True
+
+    def set_autocomplete_enabled(self, enabled: bool) -> None:
+        self.autocomplete_enabled = enabled
+
+    def focus(self) -> None:
+        pass
+
+
+class FakeKon:
+    def __init__(
+        self, selected_item: ListItem | None = None, *, completion_visible: bool | None = None
+    ) -> None:
+        self.chat = FakeChat()
+        self.info_bar = FakeInfoBar()
+        self.completion_list = FakeCompletionList(selected_item, visible=completion_visible)
+        self.input_box = FakeInputBox()
+        self._runtime = ConversationRuntime(
+            cwd=".",
+            model="fake-model",
+            model_provider="fake",
+            api_key=None,
+            base_url=None,
+            thinking_level="off",
+            tools=[],
+        )
+        self._selection_mode: SelectionMode | None = None
+        self._settings_active = False
+        self._settings_selected_value: str | None = None
+        self.reset_delete_count = 0
+        self.selected_permissions: list[str] = []
+        self.selected_themes: list[str] = []
+        self.resume_items: list[ListItem] = []
+        self.notifications: list[tuple[str, str, int, str]] = []
+
+    def query_one(self, selector: str, widget_type: object | None = None) -> Any:
+        if selector == "#chat-log":
+            return self.chat
+        if selector == "#info-bar":
+            return self.info_bar
+        if selector == "#completion-list":
+            return self.completion_list
+        if selector == "#input-box":
+            return self.input_box
+        raise AssertionError(f"Unexpected selector: {selector}")
+
+    @contextmanager
+    def batch_update(self):
+        yield
+
+    def _reset_ctrl_d_delete_state(self) -> None:
+        self.reset_delete_count += 1
+
+    def _select_permission_mode(self, mode: str) -> None:
+        self.selected_permissions.append(mode)
+
+    def _select_theme(self, theme_id: str) -> None:
+        self.selected_themes.append(theme_id)
+
+    def _kon(self) -> Kon:
+        return cast(Kon, self)
+
+    def call_after_refresh(self, callback: Callable[[], None]) -> None:
+        callback()
+
+    def call_later(self, callback: Callable[..., None], *args: Any) -> None:
+        callback(*args)
+
+    def _is_chat_at_bottom(self) -> bool:
+        return Kon._is_chat_at_bottom(self._kon())
+
+    def _restore_chat_scroll_if_needed(self, was_at_bottom: bool) -> None:
+        Kon._restore_chat_scroll_if_needed(self._kon(), was_at_bottom)
+
+    def _restore_chat_scroll_after_refresh(self, was_at_bottom: bool) -> None:
+        Kon._restore_chat_scroll_after_refresh(self._kon(), was_at_bottom)
+
+    def _set_bottom_info_displaced(self, displaced: bool) -> None:
+        Kon._set_bottom_info_displaced(self._kon(), displaced)
+
+    def _show_completion_list(
+        self,
+        items: list[ListItem],
+        *,
+        searchable: bool = False,
+        max_label_width: int | None = None,
+    ) -> None:
+        Kon._show_completion_list(
+            self._kon(), items, searchable=searchable, max_label_width=max_label_width
+        )
+
+    def _hide_completion_list(self, *, restore_info_bar: bool = True) -> None:
+        Kon._hide_completion_list(self._kon(), restore_info_bar=restore_info_bar)
+
+    def on_completion_update(self, event: InputBox.CompletionUpdate) -> None:
+        Kon.on_completion_update(self._kon(), event)
+
+    def on_completion_hide(self, event: InputBox.CompletionHide) -> None:
+        Kon.on_completion_hide(self._kon(), event)
+
+    def on_completion_select(self, event: InputBox.CompletionSelect) -> None:
+        Kon.on_completion_select(self._kon(), event)
+
+    def _show_selection_picker(
+        self,
+        items: list[ListItem],
+        selection_mode: SelectionMode,
+        *,
+        searchable: bool = True,
+        max_label_width: int | None = None,
+    ) -> None:
+        Kon._show_selection_picker(
+            self._kon(),
+            items,
+            selection_mode,
+            searchable=searchable,
+            max_label_width=max_label_width,
+        )
+
+    def _handle_settings_select(self, item_value: str):
+        return Kon._handle_settings_select(self._kon(), item_value)
+
+    def _build_settings_items(self) -> list[ListItem[str]]:
+        return Kon._build_settings_items(self._kon())
+
+    def _show_settings_picker(self, selected_value: str | None = None) -> None:
+        Kon._show_settings_picker(self._kon(), selected_value=selected_value)
+
+    def _build_resume_items(self) -> list[ListItem]:
+        return self.resume_items
+
+    def _delete_selected_resume_session(self) -> None:
+        Kon._delete_selected_resume_session(self._kon())
+
+    def notify(
+        self, message: str, *, title: str = "", timeout: int = 0, severity: str = "information"
+    ) -> None:
+        self.notifications.append((message, title, timeout, severity))
+
+    def _handle_themes_command(self, args: str) -> None:
+        Kon._handle_themes_command(self._kon(), args)
+
+    def _handle_thinking_command(self, args: str) -> None:
+        Kon._handle_thinking_command(self._kon(), args)
+
+
+def _make_session_item(path, session_id: str = "session") -> ListItem:
+    session_info = SessionInfo(
+        id=session_id,
+        path=path,
+        cwd=".",
+        created=datetime.now(UTC),
+        modified=datetime.now(UTC),
+        message_count=1,
+        first_message=session_id,
+    )
+    return ListItem(value=session_info, label=session_id)
+
+
+def test_completion_list_is_configured_for_ten_rows() -> None:
+    app = Kon(cwd=".")
+    floating_list = next(
+        widget
+        for widget in app.compose()
+        if isinstance(widget, FloatingList) and widget.id == "completion-list"
+    )
+
+    assert floating_list._window_size == 10  # pyright: ignore[reportPrivateUsage]
+
+
+def test_show_completion_list_displaces_info_bar() -> None:
+    app = FakeKon()
+    items = [ListItem(value="one", label="one")]
+
+    app._show_completion_list(items, searchable=True, max_label_width=40)
+
+    assert "-completion-hidden" in app.info_bar.classes
+    assert app.completion_list.items == items
+    assert app.completion_list.searchable is True
+    assert app.completion_list.max_label_width == 40
+
+
+def test_show_selection_picker_displaces_info_bar_and_restores_scroll() -> None:
+    app = FakeKon()
+    item = ListItem(value="one", label="one")
+
+    app._show_selection_picker([item], SelectionMode.PERMISSIONS)
+
+    assert "-completion-hidden" in app.info_bar.classes
+    assert app.completion_list.hidden is False
+    assert app.completion_list.items == [item]
+    assert app._selection_mode == SelectionMode.PERMISSIONS
+    assert app.chat.scrolled_to_end is True
+
+
+def test_completion_update_displaces_info_bar_for_visible_list() -> None:
+    app = FakeKon(completion_visible=True)
+    items = [ListItem(value="one", label="one")]
+
+    app.on_completion_update(InputBox.CompletionUpdate(items))
+
+    assert "-completion-hidden" in app.info_bar.classes
+    assert app.completion_list.updated_items == items
+    assert app.chat.scrolled_to_end is True
+
+
+@pytest.mark.parametrize(
+    ("restore_info_bar", "expected_hidden_class"), [(True, False), (False, True)]
+)
+def test_hide_completion_list_controls_info_bar_restore(
+    restore_info_bar: bool, expected_hidden_class: bool
+) -> None:
+    app = FakeKon()
+    app.info_bar.classes.add("-completion-hidden")
+
+    app._hide_completion_list(restore_info_bar=restore_info_bar)
+
+    assert app.completion_list.hidden is True
+    assert ("-completion-hidden" in app.info_bar.classes) is expected_hidden_class
+
+
+@pytest.mark.parametrize("case", ["no-item", "tab", "slash", "file"])
+def test_completion_select_terminal_paths_restore_info_bar(case: str) -> None:
+    item = None if case == "no-item" else ListItem(value="value", label="value")
+    app = FakeKon(selected_item=item, completion_visible=True)
+    app.info_bar.classes.add("-completion-hidden")
+
+    if case == "tab":
+        app.input_box.is_tab_completing = True
+    elif case == "slash":
+        app.input_box.active_provider = SlashCommandProvider(
+            [SlashCommand(name="help", description="help")]
+        )
+    elif case == "file":
+        app.input_box.active_provider = FilePathProvider(".")
+
+    app.on_completion_select(InputBox.CompletionSelect())
+
+    assert app.completion_list.hidden is True
+    assert "-completion-hidden" not in app.info_bar.classes
+    assert app.chat.scrolled_to_end is True
+
+    if case == "no-item":
+        assert app.input_box.completing is False
+        assert app.input_box.submitted is True
+    elif case == "tab":
+        assert app.input_box.tab_completed_items == [item]
+    elif case == "slash":
+        assert app.input_box.slash_completed_items == [item]
+        assert app.input_box.completing is False
+    elif case == "file":
+        assert app.input_box.file_completed_items == [item]
+        assert app.input_box.completing is False
+
+
+def test_completion_select_final_selection_mode_restores_info_bar() -> None:
+    app = FakeKon(selected_item=ListItem(value="auto", label="auto"))
+    app.info_bar.classes.add("-completion-hidden")
+    app._selection_mode = SelectionMode.PERMISSIONS
+
+    app.on_completion_select(InputBox.CompletionSelect())
+
+    assert app.completion_list.hidden is True
+    assert "-completion-hidden" not in app.info_bar.classes
+    assert app._selection_mode is None
+    assert app.input_box.cleared is True
+    assert app.input_box.autocomplete_enabled is True
+    assert app.input_box.completing is False
+    assert app.selected_permissions == ["auto"]
+    assert app.chat.scrolled_to_end is True
+
+
+def test_completion_select_settings_themes_keeps_info_bar_displaced() -> None:
+    app = FakeKon(selected_item=ListItem(value="themes", label="themes"))
+    app.info_bar.classes.add("-completion-hidden")
+    app._selection_mode = SelectionMode.SETTINGS
+
+    app.on_completion_select(InputBox.CompletionSelect())
+
+    assert "-completion-hidden" not in app.info_bar.removed_classes
+    assert "-completion-hidden" in app.info_bar.classes
+    assert app.completion_list.hidden is False
+    assert app._selection_mode == SelectionMode.THEME
+    assert app._settings_active is True
+    assert app.chat.scrolled_to_end is True
+
+
+def test_completion_select_settings_thinking_without_provider_restores_info_bar() -> None:
+    app = FakeKon(selected_item=ListItem(value="thinking", label="thinking"))
+    app.info_bar.classes.add("-completion-hidden")
+    app._selection_mode = SelectionMode.SETTINGS
+
+    app.on_completion_select(InputBox.CompletionSelect())
+
+    assert app.completion_list.hidden is True
+    assert "-completion-hidden" not in app.info_bar.classes
+    assert app._selection_mode is None
+    assert app._settings_active is False
+    assert app.chat.errors == ["Agent not initialized"]
+    assert app.chat.scrolled_to_end is True
+
+
+def test_completion_hide_from_settings_subpicker_reopens_settings_and_restores_scroll() -> None:
+    app = FakeKon(completion_visible=True)
+    app.info_bar.classes.add("-completion-hidden")
+    app._selection_mode = SelectionMode.THEME
+    app._settings_active = True
+
+    app.on_completion_hide(InputBox.CompletionHide())
+
+    assert app.completion_list.hidden is False
+    assert "-completion-hidden" in app.info_bar.classes
+    assert app._selection_mode == SelectionMode.SETTINGS
+    assert app._settings_active is False
+    assert app.chat.scrolled_to_end is True
+
+
+def test_resume_delete_no_remaining_sessions_hides_picker_and_restores_scroll(tmp_path) -> None:
+    session_path = tmp_path / "deleted.jsonl"
+    session_path.write_text("{}\n")
+    app = FakeKon(selected_item=_make_session_item(session_path))
+    app.info_bar.classes.add("-completion-hidden")
+    app._selection_mode = SelectionMode.SESSION
+
+    app._delete_selected_resume_session()
+
+    assert session_path.exists() is False
+    assert app.completion_list.hidden is True
+    assert "-completion-hidden" not in app.info_bar.classes
+    assert app.input_box.autocomplete_enabled is True
+    assert app.input_box.completing is False
+    assert app._selection_mode is None
+    assert app.notifications == [
+        ("Session deleted (no saved sessions left)", "Sessions", 2, "information")
+    ]
+    assert app.chat.scrolled_to_end is True
+
+
+def test_resume_delete_remaining_sessions_updates_picker_and_restores_scroll(tmp_path) -> None:
+    deleted_path = tmp_path / "deleted.jsonl"
+    remaining_path = tmp_path / "remaining.jsonl"
+    deleted_path.write_text("{}\n")
+    remaining_path.write_text("{}\n")
+    remaining_item = _make_session_item(remaining_path, "remaining")
+    app = FakeKon(selected_item=_make_session_item(deleted_path, "deleted"))
+    app._selection_mode = SelectionMode.SESSION
+    app.resume_items = [remaining_item]
+
+    app._delete_selected_resume_session()
+
+    assert deleted_path.exists() is False
+    assert app.completion_list.hidden is False
+    assert app.completion_list.updated_items == [remaining_item]
+    assert app.notifications == [("Session deleted", "Sessions", 2, "information")]
+    assert app.chat.scrolled_to_end is True
+
+
+def test_completion_select_settings_subpicker_reopens_settings_and_restores_scroll() -> None:
+    app = FakeKon(selected_item=ListItem(value="textual-dark", label="textual-dark"))
+    app.info_bar.classes.add("-completion-hidden")
+    app._selection_mode = SelectionMode.THEME
+    app._settings_active = True
+
+    app.on_completion_select(InputBox.CompletionSelect())
+
+    assert app.selected_themes == ["textual-dark"]
+    assert app.completion_list.hidden is False
+    assert "-completion-hidden" in app.info_bar.classes
+    assert app._selection_mode == SelectionMode.SETTINGS
+    assert app._settings_active is False
+    assert app.chat.scrolled_to_end is True

--- a/tests/ui/test_floating_list.py
+++ b/tests/ui/test_floating_list.py
@@ -5,6 +5,23 @@ def _make_items(count: int) -> list[ListItem[str]]:
     return [ListItem(value=f"v{i}", label=f"item{i}") for i in range(count)]
 
 
+def test_show_resets_max_label_width_to_constructor_default() -> None:
+    label = "x" * 35
+    items = [ListItem(value="value", label=label)]
+    floating_list: FloatingList[str] = FloatingList()
+
+    floating_list.show(items, max_label_width=40)
+    wide_render = floating_list.render().plain
+
+    floating_list.show(items)
+    default_render = floating_list.render().plain
+
+    assert label in wide_render
+    assert label not in default_render
+    assert "…" in default_render
+    assert default_render != wide_render
+
+
 def test_move_down_wraps_to_first_item() -> None:
     floating_list: FloatingList[str] = FloatingList()
     floating_list.update_items(_make_items(3))

--- a/tests/ui/test_permissions_command.py
+++ b/tests/ui/test_permissions_command.py
@@ -28,7 +28,9 @@ class FakeFloatingList:
         self.items: list[ListItem] = []
         self.searchable: bool | None = None
 
-    def show(self, items: list[ListItem], searchable: bool = False) -> None:
+    def show(
+        self, items: list[ListItem], searchable: bool = False, max_label_width: int | None = None
+    ) -> None:
         self.items = items
         self.searchable = searchable
 
@@ -76,6 +78,21 @@ class FakeCommands(CommandsMixin):
 
     def _select_permission_mode(self, mode):
         self.selected_modes.append(mode)
+
+    def _show_completion_list(
+        self,
+        items: list[ListItem],
+        *,
+        searchable: bool = False,
+        max_label_width: int | None = None,
+    ) -> None:
+        self.completion_list.show(items, searchable=searchable, max_label_width=max_label_width)
+
+    def _is_chat_at_bottom(self) -> bool:
+        return True
+
+    def _restore_chat_scroll_after_refresh(self, was_at_bottom: bool) -> None:
+        pass
 
 
 def test_settings_command_in_default_commands():

--- a/tests/ui/test_styles.py
+++ b/tests/ui/test_styles.py
@@ -14,3 +14,12 @@ def test_approval_background_blends_terminal_bg_with_accent():
 
     assert "background: #2d2e2e;" in approval_block
     assert "background: #3c3836;" not in approval_block
+
+
+def test_completion_hidden_info_bar_collapses_fixed_row():
+    styles = get_styles()
+
+    info_bar_hidden_block = styles.split(".info-bar.-completion-hidden {")[1].split("}", 1)[0]
+
+    assert "display: none;" in info_bar_hidden_block
+    assert "height: 0;" in info_bar_hidden_block

--- a/tests/ui/test_thinking_notifications_commands.py
+++ b/tests/ui/test_thinking_notifications_commands.py
@@ -34,7 +34,9 @@ class FakeFloatingList:
         self.items: list[ListItem] = []
         self.searchable: bool | None = None
 
-    def show(self, items: list[ListItem], searchable: bool = False) -> None:
+    def show(
+        self, items: list[ListItem], searchable: bool = False, max_label_width: int | None = None
+    ) -> None:
         self.items = items
         self.searchable = searchable
 
@@ -119,6 +121,21 @@ class FakeCommands(CommandsMixin):
         self._provider = self._runtime.provider
         self._session = self._runtime.session
         self._thinking_level = self._runtime.thinking_level
+
+    def _show_completion_list(
+        self,
+        items: list[ListItem],
+        *,
+        searchable: bool = False,
+        max_label_width: int | None = None,
+    ) -> None:
+        self.completion_list.show(items, searchable=searchable, max_label_width=max_label_width)
+
+    def _is_chat_at_bottom(self) -> bool:
+        return True
+
+    def _restore_chat_scroll_after_refresh(self, was_at_bottom: bool) -> None:
+        pass
 
 
 def test_thinking_command_with_argument_updates_current_session_only():


### PR DESCRIPTION
## Summary

The completion popup currently takes space above the input while the bottom info bar remains visible, which can make the picker feel cramped and cause small layout jumps around picker transitions.

I've implemented the popup so opening completion or selection pickers hides the info bar, and closing or selecting from them restores it. I also preserved bottom scroll after popup layout changes so opening, closing, selecting, and returning through settings subpickers do not leave the chat at an awkward offset.

A few related picker edge cases are covered as well:

- Settings subpickers keep the info bar displaced while returning to the settings picker
- Resume session deletion restores or updates picker chrome cleanly
- Per picker label width overrides no longer leak into later `FloatingList.show()` calls
- The completion list shows a little more room now that the info bar is displaced

From my testing, this has behaved well, but I’d still encourage you to test it yourself. I personally find this UX much cleaner.

## Validation

- `uv run ruff format .`
- `uv run python -m pytest tests/ui/test_floating_list.py tests/ui/test_completion_chrome.py`
