### PR TITLE
fix: long loading on dirs with many elements

### DIFF
--- a/src/kon/__init__.py
+++ b/src/kon/__init__.py
@@ -1,11 +1,11 @@
 from kon.config import (
-    AVAILABLE_BINARIES,
     CONFIG_DIR_NAME,
     Config,
     consume_config_warnings,
     get_agents_dir,
     get_config,
     get_config_dir,
+    get_bin_dir,
     get_legacy_config_dir,
     reload_config,
     reset_config,
@@ -14,7 +14,6 @@ from kon.config import (
     set_permissions_mode,
     set_show_welcome_shortcuts,
     set_theme,
-    update_available_binaries,
 )
 from kon.context._xml import escape_xml
 
@@ -29,7 +28,6 @@ class _ConfigProxy:
 config: Config = _ConfigProxy()  # type: ignore[assignment]
 
 __all__ = [
-    "AVAILABLE_BINARIES",
     "CONFIG_DIR_NAME",
     "Config",
     "config",
@@ -38,6 +36,7 @@ __all__ = [
     "get_agents_dir",
     "get_config",
     "get_config_dir",
+    "get_bin_dir",
     "get_legacy_config_dir",
     "reload_config",
     "reset_config",
@@ -46,5 +45,4 @@ __all__ = [
     "set_permissions_mode",
     "set_show_welcome_shortcuts",
     "set_theme",
-    "update_available_binaries",
 ]

--- a/src/kon/config.py
+++ b/src/kon/config.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from .path_migration import consume_path_migration_warnings, get_path_state, reset_path_state
 from .themes import ColorsConfig, get_theme, get_theme_ids
+from .tools_manager import detect_available_binaries
 
 CONFIG_DIR_NAME: str = "kon"
 
@@ -214,7 +215,7 @@ class Config:
 
     @property
     def binaries(self) -> _BinariesConfig:
-        return _BinariesConfig(AVAILABLE_BINARIES)
+        return _BinariesConfig(detect_available_binaries(get_bin_dir()))
 
 
 # =================================================================================================
@@ -224,6 +225,10 @@ class Config:
 
 def get_config_dir() -> Path:
     return get_path_state().config_dir
+
+
+def get_bin_dir() -> Path:
+    return get_config_dir() / "bin"
 
 
 def get_legacy_config_dir() -> Path:
@@ -254,18 +259,6 @@ def consume_config_warnings() -> list[str]:
     warnings = consume_path_migration_warnings() + _config_warnings.copy()
     _config_warnings.clear()
     return warnings
-
-
-def _detect_available_binaries() -> set[str]:
-    binaries = {"rg", "fd"}
-    available = set()
-    bin_dir = get_config_dir() / "bin"
-
-    for binary in binaries:
-        if shutil.which(binary) or (bin_dir / binary).exists():
-            available.add(binary)
-
-    return available
 
 
 def _get_config_version(data: dict[str, Any]) -> int:
@@ -486,20 +479,6 @@ def _backup_and_write_migrated_config(config_file: Path, data: dict[str, Any]) -
     shutil.copy2(config_file, backup_path)
     _atomic_write_text(config_file, _serialize_config_toml(data))
     return backup_path
-
-
-# =================================================================================================
-# Runtime Environment Capabilities
-# TODO: Consider moving runtime capability detection and caching to a dedicated runtime.py module.
-# =================================================================================================
-
-
-AVAILABLE_BINARIES = _detect_available_binaries()
-
-
-def update_available_binaries() -> None:
-    AVAILABLE_BINARIES.clear()
-    AVAILABLE_BINARIES.update(_detect_available_binaries())
 
 
 # =================================================================================================

--- a/src/kon/tools_manager.py
+++ b/src/kon/tools_manager.py
@@ -13,12 +13,7 @@ from typing import Literal
 
 import aiohttp
 
-from .config import get_config_dir
-
 ToolName = Literal["fd", "rg"]
-
-_BIN_DIR = get_config_dir() / "bin"
-
 
 @dataclass
 class _ToolConfig:
@@ -85,13 +80,13 @@ def _command_exists(cmd: str) -> bool:
     return shutil.which(cmd) is not None
 
 
-def get_tool_path(tool: ToolName) -> str | None:
+def get_tool_path(tool: ToolName, bin_dir: Path) -> str | None:
     config = _TOOLS.get(tool)
     if not config:
         return None
 
     ext = ".exe" if _get_platform() == "win32" else ""
-    local_path = _BIN_DIR / (config.binary_name + ext)
+    local_path = bin_dir / (config.binary_name + ext)
     if local_path.exists():
         return str(local_path)
 
@@ -99,6 +94,17 @@ def get_tool_path(tool: ToolName) -> str | None:
         return config.binary_name
 
     return None
+
+
+def detect_available_binaries(bin_dir: Path) -> set[str]:
+    binaries: list[ToolName] = ["rg", "fd"]
+    available = set()
+
+    for binary in binaries:
+        if get_tool_path(binary, bin_dir):
+            available.add(binary)
+
+    return available
 
 
 async def _get_latest_version(session: aiohttp.ClientSession, repo: str) -> str:
@@ -153,7 +159,7 @@ def _extract_binary(archive_path: Path, binary_name: str, dest: Path) -> Path:
     return output_path
 
 
-async def _download_tool(tool: ToolName) -> str:
+async def _download_tool(tool: ToolName, bin_dir: Path) -> str:
     # TODO: Move archive extraction and other synchronous file operations
     # off the event loop so background tool installation cannot cause UI hiccups.
     config = _TOOLS[tool]
@@ -168,24 +174,24 @@ async def _download_tool(tool: ToolName) -> str:
         if not asset_name:
             raise RuntimeError(f"No binary available for {config.name} on {plat}/{arch}")
 
-        _BIN_DIR.mkdir(parents=True, exist_ok=True)
+        bin_dir.mkdir(parents=True, exist_ok=True)
 
         download_url = (
             f"https://github.com/{config.repo}/releases/download/"
             f"{config.tag_prefix}{version}/{asset_name}"
         )
 
-        archive_path = _BIN_DIR / asset_name
+        archive_path = bin_dir / asset_name
         try:
             await _download_file(session, download_url, archive_path)
-            binary_path = _extract_binary(archive_path, config.binary_name, _BIN_DIR)
+            binary_path = _extract_binary(archive_path, config.binary_name, bin_dir)
             return str(binary_path)
         finally:
             archive_path.unlink(missing_ok=True)
 
 
-async def ensure_tool(tool: ToolName, silent: bool = False) -> str | None:
-    existing = get_tool_path(tool)
+async def ensure_tool(tool: ToolName, bin_dir: Path, silent: bool = False) -> str | None:
+    existing = get_tool_path(tool, bin_dir)
     if existing:
         return existing
 
@@ -201,7 +207,7 @@ async def ensure_tool(tool: ToolName, silent: bool = False) -> str | None:
         print(f"{config.name} not found. Downloading...", file=sys.stderr)
 
     try:
-        path = await _download_tool(tool)
+        path = await _download_tool(tool, bin_dir)
         if not silent:
             print(f"{config.name} installed to {path}", file=sys.stderr)
         return path
@@ -212,9 +218,9 @@ async def ensure_tool(tool: ToolName, silent: bool = False) -> str | None:
 
 
 async def ensure_tools(
-    tools: list[ToolName] | None = None, silent: bool = False
+    bin_dir: Path, tools: list[ToolName] | None = None, silent: bool = False
 ) -> dict[ToolName, str | None]:
     if tools is None:
         tools = ["fd", "rg"]
-    results = await asyncio.gather(*(ensure_tool(t, silent=silent) for t in tools))
+    results = await asyncio.gather(*(ensure_tool(t, bin_dir, silent=silent) for t in tools))
     return dict(zip(tools, results, strict=True))

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -336,18 +336,20 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
     def on_mount(self) -> None:
         if config.binaries.fd:
             self._fd_path = shutil.which("fd") or shutil.which("fdfind")
-        else:
-            self._fd_path = None
+
+        # fallback - our management (config.binaries.fd takes into account bins from config dir)
+        if not self._fd_path:
+            self.run_worker(self._ensure_binaries(), exclusive=False)
+
+        self.run_worker(self._check_for_updates(), exclusive=False)
 
         input_box = self.query_one("#input-box", InputBox)
-        input_box.set_fd_path(self._fd_path)
         input_box.set_commands(DEFAULT_COMMANDS.copy())
 
         if not self._fd_path:
             self.run_worker(self._collect_file_paths(), exclusive=False)
-
-        self.run_worker(self._ensure_binaries(), exclusive=False)
-        self.run_worker(self._check_for_updates(), exclusive=False)
+        else:
+            input_box.set_fd_path(self._fd_path)
 
         try:
             init_result = self._runtime.initialize(
@@ -451,7 +453,6 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
 
         if not self._fd_path and paths.get("fd"):
             self._fd_path = paths["fd"]
-            self.query_one("#input-box", InputBox).set_fd_path(self._fd_path)
 
     async def _check_for_updates(self) -> None:
         latest = await get_newer_pypi_version(_PYPI_PACKAGE_NAME, VERSION)

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -14,7 +14,7 @@ from textual import events, on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 
-from kon import config, consume_config_warnings, update_available_binaries
+from kon import config, consume_config_warnings, get_bin_dir
 from kon.tools_manager import ensure_tools
 
 from ..context.skills import (
@@ -336,20 +336,15 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
     def on_mount(self) -> None:
         if config.binaries.fd:
             self._fd_path = shutil.which("fd") or shutil.which("fdfind")
-
-        # fallback - our management (config.binaries.fd takes into account bins from config dir)
-        if not self._fd_path:
-            self.run_worker(self._ensure_binaries(), exclusive=False)
-
-        self.run_worker(self._check_for_updates(), exclusive=False)
+        else:
+            self.run_worker(self._collect_file_paths(), exclusive=False)
 
         input_box = self.query_one("#input-box", InputBox)
+        input_box.set_fd_path(self._fd_path)
         input_box.set_commands(DEFAULT_COMMANDS.copy())
 
-        if not self._fd_path:
-            self.run_worker(self._collect_file_paths(), exclusive=False)
-        else:
-            input_box.set_fd_path(self._fd_path)
+        self.run_worker(self._ensure_binaries(), exclusive=False)
+        self.run_worker(self._check_for_updates(), exclusive=False)
 
         try:
             init_result = self._runtime.initialize(
@@ -448,11 +443,11 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
         self.query_one("#input-box", InputBox).set_file_paths(paths)
 
     async def _ensure_binaries(self) -> None:
-        paths = await ensure_tools(silent=True)
-        update_available_binaries()
+        paths = await ensure_tools(get_bin_dir(), silent=True)
 
         if not self._fd_path and paths.get("fd"):
             self._fd_path = paths["fd"]
+            self.query_one("#input-box", InputBox).set_fd_path(self._fd_path)
 
     async def _check_for_updates(self) -> None:
         latest = await get_newer_pypi_version(_PYPI_PACKAGE_NAME, VERSION)


### PR DESCRIPTION
Was: if no `fd` on system path always fallback to glob - long loading in dirs with many elements (ex. root of disk)

Now: check `fd` in system path (little overhead with `config.binaries.fd`) then check/update `fd` in config dir and fallback to glob