### PR TITLE
fix: use managed fd path for UI completion

### DIFF
--- a/src/kon/tools_manager.py
+++ b/src/kon/tools_manager.py
@@ -81,10 +81,6 @@ def _get_arch() -> str:
     return "x86_64"
 
 
-def _command_exists(cmd: str) -> bool:
-    return shutil.which(cmd) is not None
-
-
 def get_tool_path(tool: ToolName) -> str | None:
     config = _TOOLS.get(tool)
     if not config:
@@ -95,10 +91,10 @@ def get_tool_path(tool: ToolName) -> str | None:
     if local_path.exists():
         return str(local_path)
 
-    if _command_exists(config.binary_name):
-        return config.binary_name
+    if tool == "fd":
+        return shutil.which("fd") or shutil.which("fdfind")
 
-    return None
+    return shutil.which(config.binary_name)
 
 
 async def _get_latest_version(session: aiohttp.ClientSession, repo: str) -> str:

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import glob
 import os
-import shutil
 import time
 import tomllib
 from collections import deque
@@ -15,7 +14,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 
 from kon import config, consume_config_warnings, update_available_binaries
-from kon.tools_manager import ensure_tools
+from kon.tools_manager import ensure_tools, get_tool_path
 
 from ..context.skills import (
     load_builtin_cmd_skills,
@@ -334,10 +333,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
             self.copy_to_clipboard(selection)
 
     def on_mount(self) -> None:
-        if config.binaries.fd:
-            self._fd_path = shutil.which("fd") or shutil.which("fdfind")
-        else:
-            self._fd_path = None
+        self._fd_path = get_tool_path("fd")
 
         input_box = self.query_one("#input-box", InputBox)
         input_box.set_fd_path(self._fd_path)

--- a/tests/test_tools_manager.py
+++ b/tests/test_tools_manager.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from kon.tools_manager import _extract_binary
+from kon.tools_manager import _extract_binary, get_tool_path
 
 
 def test_extract_binary_rejects_zip_path_traversal(tmp_path: Path):
@@ -16,3 +16,27 @@ def test_extract_binary_rejects_zip_path_traversal(tmp_path: Path):
 
     with pytest.raises(ValueError, match="escapes target directory"):
         _extract_binary(archive, "evil.txt", dest)
+
+
+def test_get_tool_path_returns_config_bin_fd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fd_path = bin_dir / "fd"
+    fd_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr("kon.tools_manager._BIN_DIR", bin_dir)
+
+    assert get_tool_path("fd") == str(fd_path)
+
+
+def test_get_tool_path_supports_system_fdfind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr("kon.tools_manager._BIN_DIR", tmp_path / "missing")
+
+    def fake_which(command: str) -> str | None:
+        if command == "fdfind":
+            return "/usr/bin/fdfind"
+        return None
+
+    monkeypatch.setattr("kon.tools_manager.shutil.which", fake_which)
+
+    assert get_tool_path("fd") == "/usr/bin/fdfind"


### PR DESCRIPTION
## Summary
- resolve UI path completion fd via tools_manager.get_tool_path()
- preserve fdfind support in tool path resolution
- avoid glob fallback when fd already exists in Kon's config bin

## Tests
- uv run ruff format .
- uv run ruff check .
- uv run python -m pyright .
- uv run python -m pytest