### PR TITLE
feat: add non-interactive prompt mode

### DIFF
--- a/.agents/skills/kon-release-publish/SKILL.md
+++ b/.agents/skills/kon-release-publish/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when the user asks to cut a new Kon version, tag it, publish to P
 ## Files to bump
 
 - `pyproject.toml` → `[project].version`
-- `src/kon/ui/app.py` → fallback `VERSION = "..."`
+- `src/kon/version.py` → fallback `VERSION = "..."`
 - `uv.lock` → local package version block
 
 ## Release workflow

--- a/README.md
+++ b/README.md
@@ -69,34 +69,48 @@ kon
 ```text
 usage: kon [-h] [--model MODEL]
            [--provider {azure-ai-foundry,deepseek,github-copilot,openai,openai-codex,openai-responses,zhipu}]
-           [--api-key API_KEY] [--base-url BASE_URL] [--continue]
-           [--resume RESUME_SESSION] [--version]
-           [--extra-tools EXTRA_TOOLS]
+           [--prompt [PROMPT]] [--api-key API_KEY] [--base-url BASE_URL]
+           [--openai-compat-auth {auto,required,none}]
+           [--anthropic-compat-auth {auto,required,none}]
+           [--insecure-skip-verify] [--continue] [--resume RESUME_SESSION]
+           [--version] [--extra-tools EXTRA_TOOLS]
 
-Kon TUI
+Kon
 
 options:
   -h, --help            show this help message and exit
   --model, -m MODEL     Model to use
-  --provider, -p {azure-ai-foundry,deepseek,github-copilot,openai,openai-codex,openai-responses,zhipu}
+  --provider {azure-ai-foundry,deepseek,github-copilot,openai,openai-codex,openai-responses,zhipu}
                         Provider to use
+  --prompt, -p [PROMPT]
+                        Run a single prompt non-interactively, then exit (omit
+                        the value or pipe stdin to read the prompt from stdin)
   --api-key, -k API_KEY
                         API key
   --base-url, -u BASE_URL
                         Base URL for API
+  --openai-compat-auth {auto,required,none}
+                        Auth mode for OpenAI-compatible endpoints
+  --anthropic-compat-auth {auto,required,none}
+                        Auth mode for Anthropic-compatible endpoints
+  --insecure-skip-verify
+                        Skip TLS verification (e.g. self-signed certs on local
+                        providers)
   --continue, -c        Resume the most recent session
   --resume, -r RESUME_SESSION
-                        Resume a specific session by ID (full or unique prefix)
+                        Resume a specific session by ID (full or unique
+                        prefix)
   --version             show program's version number and exit
   --extra-tools EXTRA_TOOLS
-                        Comma-separated extra tools to enable (e.g. web_search,web_fetch)
+                        Comma-separated extra tools to enable (e.g.
+                        web_search,web_fetch)
 ```
 
 ### Common examples
 
 ```bash
-# choose a model explicitly
-kon -p openai-codex -m gpt-5.4
+# choose a provider and model explicitly
+kon --provider openai-codex -m gpt-5.4
 
 # continue your latest session
 kon -c
@@ -119,6 +133,23 @@ kon --extra-tools web_search,web_fetch
 !!grep -r "TODO" src/
 !!find . -name "*.py" | head -20
 ```
+
+### Non-interactive
+
+Run a single prompt headlessly with `-p`/`--prompt`, then exit:
+
+```bash
+# pass the prompt inline
+kon -p "fix the failing test"
+
+# read the prompt from stdin
+cat task.md | kon -p
+
+# capture the final response
+kon -p "summarize this module" > out.txt
+```
+
+In this mode tools run **auto-approved** (no confirmation prompts). The final assistant response is printed to stdout on a clean finish; errors go to stderr. Exit codes: `0` completed, `1` error, `2` startup error (empty prompt or provider/init failure), `3` hit the max-turn limit. Session flags (`-c`/`--continue`, `-r`/`--resume`) aren't supported in this mode.
 
 ### Install from source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 ]
 
 [project.scripts]
-kon = "kon.ui.app:main"
+kon = "kon.cli:main"
 
 [tool.ruff]
 target-version = "py312"

--- a/src/kon/cli.py
+++ b/src/kon/cli.py
@@ -1,0 +1,68 @@
+import argparse
+
+from kon import config
+
+from .llm import PROVIDER_API_BY_NAME
+from .version import VERSION
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Kon TUI")
+    parser.add_argument("--model", "-m", help="Model to use")
+    parser.add_argument(
+        "--provider", "-p", choices=sorted(PROVIDER_API_BY_NAME), help="Provider to use"
+    )
+    parser.add_argument("--api-key", "-k", help="API key")
+    parser.add_argument("--base-url", "-u", help="Base URL for API")
+    parser.add_argument(
+        "--openai-compat-auth",
+        choices=("auto", "required", "none"),
+        help="Auth mode for OpenAI-compatible endpoints",
+    )
+    parser.add_argument(
+        "--anthropic-compat-auth",
+        choices=("auto", "required", "none"),
+        help="Auth mode for Anthropic-compatible endpoints",
+    )
+    parser.add_argument(
+        "--insecure-skip-verify",
+        action="store_true",
+        help="Skip TLS verification (e.g. self-signed certs on local providers)",
+    )
+    parser.add_argument(
+        "--continue",
+        "-c",
+        action="store_true",
+        dest="continue_recent",
+        help="Resume the most recent session",
+    )
+    parser.add_argument(
+        "--resume",
+        "-r",
+        dest="resume_session",
+        help="Resume a specific session by ID (full or unique prefix)",
+    )
+    parser.add_argument("--version", action="version", version=f"kon {VERSION}")
+    parser.add_argument(
+        "--extra-tools", help="Comma-separated extra tools to enable (e.g. web_search,web_fetch)"
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    if args.insecure_skip_verify:
+        config.llm.tls.insecure_skip_verify = True
+
+    extra_tools = (
+        [t.strip() for t in args.extra_tools.split(",") if t.strip()] if args.extra_tools else None
+    )
+
+    from .ui.app import run_tui
+
+    run_tui(args, extra_tools=extra_tools)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kon/cli.py
+++ b/src/kon/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 
 from kon import config
 
@@ -7,10 +8,17 @@ from .version import VERSION
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Kon TUI")
+    parser = argparse.ArgumentParser(description="Kon")
     parser.add_argument("--model", "-m", help="Model to use")
+    parser.add_argument("--provider", choices=sorted(PROVIDER_API_BY_NAME), help="Provider to use")
     parser.add_argument(
-        "--provider", "-p", choices=sorted(PROVIDER_API_BY_NAME), help="Provider to use"
+        "--prompt",
+        "-p",
+        nargs="?",
+        const="-",
+        default=None,
+        help="Run a single prompt non-interactively, then exit "
+        "(omit the value or pipe stdin to read the prompt from stdin)",
     )
     parser.add_argument("--api-key", "-k", help="API key")
     parser.add_argument("--base-url", "-u", help="Base URL for API")
@@ -50,7 +58,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
-    args = build_parser().parse_args()
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.prompt is not None and (args.continue_recent or args.resume_session):
+        parser.error("-c/--continue and -r/--resume are not supported with -p/--prompt")
 
     if args.insecure_skip_verify:
         config.llm.tls.insecure_skip_verify = True
@@ -58,6 +70,24 @@ def main() -> None:
     extra_tools = (
         [t.strip() for t in args.extra_tools.split(",") if t.strip()] if args.extra_tools else None
     )
+
+    if args.prompt is not None:
+        from .headless import run_headless
+
+        raise SystemExit(
+            asyncio.run(
+                run_headless(
+                    prompt_arg=args.prompt,
+                    model=args.model,
+                    provider=args.provider,
+                    api_key=args.api_key,
+                    base_url=args.base_url,
+                    openai_compat_auth_mode=args.openai_compat_auth,
+                    anthropic_compat_auth_mode=args.anthropic_compat_auth,
+                    extra_tools=extra_tools,
+                )
+            )
+        )
 
     from .ui.app import run_tui
 

--- a/src/kon/headless.py
+++ b/src/kon/headless.py
@@ -1,0 +1,127 @@
+import os
+import sys
+from collections.abc import AsyncIterator
+from typing import TextIO
+
+from kon import config, get_config
+
+from .core.types import StopReason, TextContent
+from .events import AgentEndEvent, ErrorEvent, Event, ToolApprovalEvent, TurnEndEvent
+from .llm.base import AuthMode
+from .permissions import ApprovalResponse
+from .runtime import ConversationRuntime
+from .tools import DEFAULT_TOOLS, EXTRA_TOOLS, get_tools
+
+_EXIT_CODES = {StopReason.STOP: 0, StopReason.ERROR: 1, StopReason.LENGTH: 3}
+
+
+def _exit_code(stop: StopReason) -> int:
+    return _EXIT_CODES.get(stop, 1)
+
+
+def resolve_prompt(prompt_arg: str, *, stdin: TextIO) -> str:
+    if prompt_arg == "-":
+        return stdin.read().strip()
+    return prompt_arg.strip()
+
+
+async def render_run(
+    events: AsyncIterator[Event], *, out: TextIO | None = None, err: TextIO | None = None
+) -> StopReason:
+    out = sys.stdout if out is None else out
+    err = sys.stderr if err is None else err
+    final_text = ""
+    stop = StopReason.ERROR
+    async for event in events:
+        match event:
+            case TurnEndEvent(assistant_message=msg) if msg is not None:
+                text = "".join(p.text for p in msg.content if isinstance(p, TextContent)).strip()
+                if text:
+                    final_text = text
+            case AgentEndEvent(stop_reason=stop_reason):
+                stop = stop_reason
+            case ErrorEvent(error=error):
+                print(f"error: {error}", file=err)
+            case ToolApprovalEvent(tool_name=tool_name, future=future) if future is not None:
+                future.set_result(ApprovalResponse.DENY)
+                print(
+                    f"error: {tool_name!r} requires approval, denied (non-interactive mode)",
+                    file=err,
+                )
+            case _:
+                pass
+    if stop == StopReason.STOP and final_text:
+        print(final_text, file=out)
+    return stop
+
+
+async def run_headless(
+    *,
+    prompt_arg: str,
+    model: str | None,
+    provider: str | None,
+    api_key: str | None,
+    base_url: str | None,
+    openai_compat_auth_mode: AuthMode | None,
+    anthropic_compat_auth_mode: AuthMode | None,
+    extra_tools: list[str] | None,
+) -> int:
+    prompt = resolve_prompt(prompt_arg, stdin=sys.stdin)
+    if not prompt:
+        print("error: empty prompt", file=sys.stderr)
+        return 2
+
+    cfg = get_config()
+    previous_permission_mode = cfg.permissions.mode
+    # Headless can't show approval prompts; force auto in-memory for this run only.
+    cfg.permissions.mode = "auto"
+
+    try:
+        initial_model = model or config.llm.default_model
+        initial_provider = (
+            provider
+            if provider is not None
+            else (config.llm.default_provider if model is None else None)
+        )
+        base = base_url or config.llm.default_base_url or None
+        thinking = config.llm.default_thinking_level
+        openai_auth = openai_compat_auth_mode or config.llm.auth.openai_compat
+        anthropic_auth = anthropic_compat_auth_mode or config.llm.auth.anthropic_compat
+
+        merged = list(dict.fromkeys(config.tools.extra + (extra_tools or [])))
+        for name in merged:
+            if name not in EXTRA_TOOLS:
+                print(f"warning: unknown extra tool: {name!r}", file=sys.stderr)
+        extras = [n for n in merged if n in EXTRA_TOOLS]
+        tools = get_tools(DEFAULT_TOOLS + extras)
+
+        runtime = ConversationRuntime(
+            cwd=os.getcwd(),
+            model=initial_model,
+            model_provider=initial_provider,
+            api_key=api_key,
+            base_url=base,
+            thinking_level=thinking,
+            tools=tools,
+            openai_compat_auth_mode=openai_auth,
+            anthropic_compat_auth_mode=anthropic_auth,
+        )
+
+        try:
+            init = runtime.initialize()
+            if init.provider_error:
+                print(f"error: {init.provider_error}", file=sys.stderr)
+                return 2
+
+            agent = runtime.prepare_for_run()
+        except Exception as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+
+        if agent is None:
+            print("error: agent initialization failed", file=sys.stderr)
+            return 2
+
+        return _exit_code(await render_run(agent.run(prompt)))
+    finally:
+        cfg.permissions.mode = previous_permission_mode

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -1,11 +1,9 @@
+import argparse
 import asyncio
 import glob
 import os
 import time
-import tomllib
 from collections import deque
-from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
 from typing import ClassVar, Literal
 
 from rich.console import Console
@@ -15,6 +13,7 @@ from textual.binding import Binding
 
 from kon import config, consume_config_warnings, update_available_binaries
 from kon.tools_manager import ensure_tools, get_tool_path
+from kon.version import PACKAGE_NAME, VERSION
 
 from ..context.skills import (
     load_builtin_cmd_skills,
@@ -46,7 +45,7 @@ from ..events import (
     TurnStartEvent,
     WarningEvent,
 )
-from ..llm import PROVIDER_API_BY_NAME, BaseProvider
+from ..llm import BaseProvider
 from ..llm.base import AuthMode
 from ..notify import NotificationEvent, notify
 from ..permissions import ApprovalResponse
@@ -67,25 +66,7 @@ from .styles import get_styles
 from .tree import TreeSelector
 from .widgets import InfoBar, QueueDisplay, StatusLine, format_path
 
-
-def _get_package_name() -> str:
-    pyproject_path = Path(__file__).parent.parent.parent.parent / "pyproject.toml"
-    if pyproject_path.exists():
-        try:
-            data = tomllib.loads(pyproject_path.read_text())
-            return data["project"]["name"]
-        except Exception:
-            pass
-    return "kon-coding-agent"
-
-
-_PYPI_PACKAGE_NAME = _get_package_name()
 _CHANGELOG_URL = "https://github.com/0xku/kon/blob/main/CHANGELOG.md"
-
-try:
-    VERSION = version(_PYPI_PACKAGE_NAME)
-except PackageNotFoundError:
-    VERSION = "0.3.11"
 
 _NOTIFY_EVENTS = (AgentEndEvent, ToolApprovalEvent)
 _GIT_BRANCH_REFRESH_INTERVAL_SECONDS = 1.0
@@ -448,7 +429,7 @@ class Kon(CommandsMixin, SessionUIMixin, App[None]):
             self.query_one("#input-box", InputBox).set_fd_path(self._fd_path)
 
     async def _check_for_updates(self) -> None:
-        latest = await get_newer_pypi_version(_PYPI_PACKAGE_NAME, VERSION)
+        latest = await get_newer_pypi_version(PACKAGE_NAME, VERSION)
         if latest is None:
             return
 
@@ -1488,57 +1469,7 @@ def _print_exit_message(
     console.print()
 
 
-def main():
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Kon TUI")
-    parser.add_argument("--model", "-m", help="Model to use")
-    parser.add_argument(
-        "--provider", "-p", choices=sorted(PROVIDER_API_BY_NAME), help="Provider to use"
-    )
-    parser.add_argument("--api-key", "-k", help="API key")
-    parser.add_argument("--base-url", "-u", help="Base URL for API")
-    parser.add_argument(
-        "--openai-compat-auth",
-        choices=("auto", "required", "none"),
-        help="Auth mode for OpenAI-compatible endpoints",
-    )
-    parser.add_argument(
-        "--anthropic-compat-auth",
-        choices=("auto", "required", "none"),
-        help="Auth mode for Anthropic-compatible endpoints",
-    )
-    parser.add_argument(
-        "--insecure-skip-verify",
-        action="store_true",
-        help="Skip TLS verification (e.g. self-signed certs on local providers)",
-    )
-    parser.add_argument(
-        "--continue",
-        "-c",
-        action="store_true",
-        dest="continue_recent",
-        help="Resume the most recent session",
-    )
-    parser.add_argument(
-        "--resume",
-        "-r",
-        dest="resume_session",
-        help="Resume a specific session by ID (full or unique prefix)",
-    )
-    parser.add_argument("--version", action="version", version=f"kon {VERSION}")
-    parser.add_argument(
-        "--extra-tools", help="Comma-separated extra tools to enable (e.g. web_search,web_fetch)"
-    )
-    args = parser.parse_args()
-
-    if args.insecure_skip_verify:
-        config.llm.tls.insecure_skip_verify = True
-
-    extra_tools = (
-        [t.strip() for t in args.extra_tools.split(",") if t.strip()] if args.extra_tools else None
-    )
-
+def run_tui(args: argparse.Namespace, *, extra_tools: list[str] | None) -> None:
     app = Kon(
         model=args.model,
         provider=args.provider,
@@ -1565,7 +1496,3 @@ def main():
 
     if hints or session_id:
         _print_exit_message(hints, session_id, duration, file_changes)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/kon/version.py
+++ b/src/kon/version.py
@@ -1,0 +1,22 @@
+import tomllib
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _get_package_name() -> str:
+    pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+    if pyproject_path.exists():
+        try:
+            data = tomllib.loads(pyproject_path.read_text())
+            return data["project"]["name"]
+        except Exception:
+            pass
+    return "kon-coding-agent"
+
+
+PACKAGE_NAME = _get_package_name()
+
+try:
+    VERSION = version(PACKAGE_NAME)
+except PackageNotFoundError:
+    VERSION = "0.3.11"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+
+from kon.cli import build_parser, main
+
+
+def test_prompt_flag_takes_value():
+    assert build_parser().parse_args(["-p", "hi"]).prompt == "hi"
+
+
+def test_bare_prompt_flag_means_stdin():
+    assert build_parser().parse_args(["-p"]).prompt == "-"
+
+
+def test_provider_uses_long_form():
+    assert build_parser().parse_args(["--provider", "openai"]).provider == "openai"
+
+
+def test_prompt_no_longer_feeds_provider():
+    assert build_parser().parse_args(["-p", "x"]).provider is None
+
+
+def test_option_after_bare_prompt_falls_back_to_stdin():
+    args = build_parser().parse_args(["-p", "-m", "x"])
+    assert args.prompt == "-"
+    assert args.model == "x"
+
+
+@pytest.mark.parametrize("flag", [["-c"], ["-r", "abc123"]])
+def test_resume_flags_rejected_with_prompt(monkeypatch, flag):
+    monkeypatch.setattr(sys, "argv", ["kon", "-p", "x", *flag])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 2

--- a/tests/test_cli_auth_flags.py
+++ b/tests/test_cli_auth_flags.py
@@ -1,12 +1,4 @@
-import argparse
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Kon TUI")
-    parser.add_argument("--openai-compat-auth", choices=("auto", "required", "none"))
-    parser.add_argument("--anthropic-compat-auth", choices=("auto", "required", "none"))
-    parser.add_argument("--insecure-skip-verify", action="store_true")
-    return parser
+from kon.cli import build_parser
 
 
 def test_cli_auth_flags_accept_valid_values() -> None:

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -1,0 +1,207 @@
+import asyncio
+from io import StringIO
+
+import pytest
+
+from kon import get_config
+from kon.core.types import AssistantMessage, StopReason, TextContent
+from kon.events import AgentEndEvent, ErrorEvent, ToolApprovalEvent, TurnEndEvent
+from kon.headless import _exit_code, render_run, resolve_prompt, run_headless
+from kon.llm.providers.mock import MockProvider
+from kon.loop import Agent
+from kon.permissions import ApprovalResponse
+from kon.session import Session
+
+
+async def _emit(events):
+    for event in events:
+        yield event
+
+
+async def _run_headless(prompt_arg, *, extra_tools=None):
+    return await run_headless(
+        prompt_arg=prompt_arg,
+        model=None,
+        provider=None,
+        api_key=None,
+        base_url=None,
+        openai_compat_auth_mode=None,
+        anthropic_compat_auth_mode=None,
+        extra_tools=extra_tools,
+    )
+
+
+def test_resolve_prompt_literal_strips():
+    assert resolve_prompt("  hello  ", stdin=StringIO("ignored")) == "hello"
+
+
+def test_resolve_prompt_reads_stdin_on_dash():
+    assert resolve_prompt("-", stdin=StringIO("  from stdin  ")) == "from stdin"
+
+
+def test_resolve_prompt_whitespace_only_is_empty():
+    assert resolve_prompt("   ", stdin=StringIO("")) == ""
+
+
+@pytest.mark.asyncio
+async def test_render_run_prints_final_text_on_stop():
+    out, err = StringIO(), StringIO()
+    events = _emit(
+        [
+            TurnEndEvent(
+                turn=1,
+                assistant_message=AssistantMessage(
+                    content=[TextContent(text="final answer")], stop_reason=StopReason.STOP
+                ),
+                tool_results=[],
+                stop_reason=StopReason.STOP,
+            ),
+            AgentEndEvent(stop_reason=StopReason.STOP),
+        ]
+    )
+    stop = await render_run(events, out=out, err=err)
+    assert stop == StopReason.STOP
+    assert out.getvalue() == "final answer\n"
+    assert err.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_render_run_error_goes_to_stderr_only():
+    out, err = StringIO(), StringIO()
+    events = _emit([ErrorEvent(error="boom"), AgentEndEvent(stop_reason=StopReason.ERROR)])
+    stop = await render_run(events, out=out, err=err)
+    assert stop == StopReason.ERROR
+    assert "error: boom" in err.getvalue()
+    assert out.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_render_run_suppresses_text_when_not_stop():
+    out, err = StringIO(), StringIO()
+    events = _emit(
+        [
+            TurnEndEvent(
+                turn=1,
+                assistant_message=AssistantMessage(
+                    content=[TextContent(text="partial")], stop_reason=StopReason.ERROR
+                ),
+                tool_results=[],
+                stop_reason=StopReason.ERROR,
+            ),
+            AgentEndEvent(stop_reason=StopReason.ERROR),
+        ]
+    )
+    stop = await render_run(events, out=out, err=err)
+    assert stop == StopReason.ERROR
+    assert out.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_render_run_composition_simple_text():
+    agent = Agent(MockProvider(scenario="simple_text"), [], Session.in_memory())
+    out, err = StringIO(), StringIO()
+    stop = await render_run(agent.run("hi"), out=out, err=err)
+    assert stop == StopReason.STOP
+    assert out.getvalue() == "Hello, world!\n"
+
+
+@pytest.mark.asyncio
+async def test_render_run_composition_stream_error():
+    agent = Agent(MockProvider(scenario="stream_error"), [], Session.in_memory())
+    out, err = StringIO(), StringIO()
+    stop = await render_run(agent.run("hi"), out=out, err=err)
+    assert stop == StopReason.ERROR
+    assert out.getvalue() == ""
+    assert "error" in err.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_run_headless_prints_and_restores_permissions(monkeypatch, capsys):
+    get_config().permissions.mode = "prompt"
+    monkeypatch.setattr(
+        "kon.runtime.create_provider",
+        lambda api_type, config: MockProvider(config, scenario="simple_text"),
+    )
+    code = await _run_headless("hi")
+    assert code == 0
+    assert get_config().permissions.mode == "prompt"
+    assert "Hello, world!" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_run_headless_sets_auto_during_run_and_restores(monkeypatch):
+    get_config().permissions.mode = "prompt"
+    monkeypatch.setattr(
+        "kon.runtime.create_provider",
+        lambda api_type, config: MockProvider(config, scenario="simple_text"),
+    )
+
+    async def fake_render_run(events):
+        assert get_config().permissions.mode == "auto"
+        return StopReason.STOP
+
+    monkeypatch.setattr("kon.headless.render_run", fake_render_run)
+
+    code = await _run_headless("hi")
+    assert code == 0
+    assert get_config().permissions.mode == "prompt"
+
+
+@pytest.mark.asyncio
+async def test_run_headless_warns_on_unknown_extra_tool(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "kon.runtime.create_provider",
+        lambda api_type, config: MockProvider(config, scenario="simple_text"),
+    )
+    code = await _run_headless("hi", extra_tools=["bogus"])
+    assert code == 0
+    assert "unknown extra tool: 'bogus'" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_run_headless_empty_prompt_returns_2(capsys):
+    code = await _run_headless("   ")
+    assert code == 2
+    assert "empty prompt" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_run_headless_init_exception_returns_2(capsys):
+    code = await run_headless(
+        prompt_arg="hi",
+        model="definitely-not-a-model",
+        provider="bogus",
+        api_key=None,
+        base_url=None,
+        openai_compat_auth_mode=None,
+        anthropic_compat_auth_mode=None,
+        extra_tools=None,
+    )
+
+    assert code == 2
+    assert "error:" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_render_run_denies_tool_approval():
+    future = asyncio.get_running_loop().create_future()
+    out, err = StringIO(), StringIO()
+    events = _emit(
+        [
+            ToolApprovalEvent(
+                tool_call_id="t1", tool_name="bash", display="rm -rf /", future=future
+            ),
+            AgentEndEvent(stop_reason=StopReason.STOP),
+        ]
+    )
+    stop = await render_run(events, out=out, err=err)
+    assert future.result() == ApprovalResponse.DENY
+    assert "requires approval" in err.getvalue()
+    assert stop == StopReason.STOP
+
+
+def test_exit_code_mapping():
+    assert _exit_code(StopReason.STOP) == 0
+    assert _exit_code(StopReason.ERROR) == 1
+    assert _exit_code(StopReason.LENGTH) == 3
+    assert _exit_code(StopReason.INTERRUPTED) == 1

--- a/tests/test_llm_lazy_imports.py
+++ b/tests/test_llm_lazy_imports.py
@@ -17,11 +17,17 @@ def _module_loaded(loaded: set[str], module_name: str) -> bool:
     return any(name == module_name or name.startswith(f"{module_name}.") for name in loaded)
 
 
-@pytest.mark.parametrize("import_target", ["kon.llm", "kon.ui.app"])
+@pytest.mark.parametrize("import_target", ["kon.llm", "kon.ui.app", "kon.cli"])
 def test_import_does_not_load_provider_sdks(import_target):
     loaded = _modules_loaded_after(import_target)
     assert not _module_loaded(loaded, "openai")
     assert not _module_loaded(loaded, "anthropic")
+
+
+@pytest.mark.parametrize("import_target", ["kon.cli"])
+def test_import_does_not_load_textual(import_target):
+    loaded = _modules_loaded_after(import_target)
+    assert not _module_loaded(loaded, "textual")
 
 
 _PROVIDER_CASES = [

--- a/tests/test_llm_lazy_imports.py
+++ b/tests/test_llm_lazy_imports.py
@@ -17,14 +17,14 @@ def _module_loaded(loaded: set[str], module_name: str) -> bool:
     return any(name == module_name or name.startswith(f"{module_name}.") for name in loaded)
 
 
-@pytest.mark.parametrize("import_target", ["kon.llm", "kon.ui.app", "kon.cli"])
+@pytest.mark.parametrize("import_target", ["kon.llm", "kon.ui.app", "kon.cli", "kon.headless"])
 def test_import_does_not_load_provider_sdks(import_target):
     loaded = _modules_loaded_after(import_target)
     assert not _module_loaded(loaded, "openai")
     assert not _module_loaded(loaded, "anthropic")
 
 
-@pytest.mark.parametrize("import_target", ["kon.cli"])
+@pytest.mark.parametrize("import_target", ["kon.cli", "kon.headless"])
 def test_import_does_not_load_textual(import_target):
     loaded = _modules_loaded_after(import_target)
     assert not _module_loaded(loaded, "textual")


### PR DESCRIPTION
## Summary

Adds a non-interactive mode: `kon -p "<prompt>"` runs a single prompt through the agent loop, prints the final response to stdout, and exits with a status code. The prompt can be passed inline or read from stdin with a bare `-p` (`cat task.md | kon -p`).

I moved the entry point out of `kon.ui.app` into a new `kon.cli` for argument parsing and dispatch, then added `kon.version` and turned the old `main()` body into `run_tui()` (with no intended change to TUI behavior). Since `kon.cli` and `kon.headless` import neither Textual nor the provider SDKs, a non-interactive run starts without the UI, which tests should verify.

Because there's no UI to approve tool calls, headless forces the permission mode to `auto` in memory for the duration of the run without writing the user's config. On a clean finish the final response would go to stdout, and errors would go to stderr. The exit code reflects the outcome: `0` on success, `1` on error, `2` on a startup failure (empty prompt, provider error, or initialization failure), and `3` when it reaches the turn limit. `-c` and `-r` don't apply to headless mode and are currently rejected rather than silently ignored.

## Breaking change

`-p` is now the short flag for `--prompt` rather than `--provider`. Use `--provider` to choose a provider.

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run python -m pyright .`
- `uv run python -m pytest`
