### PR TITLE
Rename skill tag location -> path

### DIFF
--- a/src/kon/context/skills.py
+++ b/src/kon/context/skills.py
@@ -367,7 +367,7 @@ def formatted_skills(skills: list[Skill]) -> str:
         lines.append("<skill>")
         lines.append(f"<name>{escape_xml(skill.name)}</name>")
         lines.append(f"<description>{escape_xml(skill.description)}</description>")
-        lines.append(f"<location>{escape_xml(skill.path)}</location>")
+        lines.append(f"<path>{escape_xml(skill.path)}</path>")
         lines.append("</skill>")
 
     lines.append("</available_skills>")

--- a/tests/context/test_skills.py
+++ b/tests/context/test_skills.py
@@ -542,7 +542,7 @@ class TestFormatSkillsForPrompt:
         assert "<available_skills>" in result
         assert "<name>test-skill</name>" in result
         assert "<description>A test skill</description>" in result
-        assert "<location>/path/to/SKILL.md</location>" in result
+        assert "<path>/path/to/SKILL.md</path>" in result
         assert "</available_skills>" in result
 
     def test_escapes_xml_chars(self):


### PR DESCRIPTION
Rename in sys prompt skill tags <location> to <path> to confuse llm less.