### PR TITLE
fix: test_skills.py:test_local_overrides_global_name_collision assertion in Win

### DIFF
--- a/tests/context/test_skills.py
+++ b/tests/context/test_skills.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 from kon.context.skills import (
@@ -368,7 +369,10 @@ description: Global version
 """)
 
         monkeypatch.setattr("kon.context.skills.get_config_dir", lambda: global_dir)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        if sys.platform == "win32":
+            monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        else:
+            monkeypatch.setenv("HOME", str(tmp_path))
 
         result = load_skills(str(repo))
 


### PR DESCRIPTION
No HOME for Win.