### PR TITLE
feat: add configurable cooldown between agent turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ buffer_tokens = 20000             # compact this many tokens before the context 
 [agent]
 max_turns = 500
 default_context_window = 200000
+turn_cooldown_seconds = 0         # pause this long after each LLM turn before the next one; 0 disables
 
 [tools]
 extra = ["web_search", "web_fetch"] # extra built-in tools beyond the core 6

--- a/src/kon/async_utils.py
+++ b/src/kon/async_utils.py
@@ -38,3 +38,12 @@ async def await_or_cancel[T](work: asyncio.Future[T], cancel_event: asyncio.Even
         return work.result()
     finally:
         await cancel_and_await(cancel)
+
+
+async def sleep_or_cancel(delay: float, cancel_event: asyncio.Event | None) -> bool:
+    """Sleep for `delay` seconds, returning True if cancelled early instead of completing."""
+    try:
+        await await_or_cancel(asyncio.create_task(asyncio.sleep(delay)), cancel_event)
+        return False
+    except OperationCancelledError:
+        return True

--- a/src/kon/config.py
+++ b/src/kon/config.py
@@ -112,6 +112,7 @@ class CompactionConfig(BaseModel):
 class AgentConfig(BaseModel):
     max_turns: int = 500
     default_context_window: int = 200000
+    turn_cooldown_seconds: float = 0
 
 
 class PermissionsConfig(BaseModel):

--- a/src/kon/defaults/config.toml
+++ b/src/kon/defaults/config.toml
@@ -53,6 +53,9 @@ buffer_tokens = 20000
 # Prevents runaway loops when the agent keeps calling tools or continuing.
 max_turns = 500
 default_context_window = 200000
+# Seconds to wait after each completed LLM turn before starting the next one.
+# Useful for staying under provider rate limits. 0 disables the cooldown.
+turn_cooldown_seconds = 0
 
 [tools]
 # Additional opt-in built-in tools to expose beyond the default tool set.

--- a/src/kon/loop.py
+++ b/src/kon/loop.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from . import config as kon_config
+from .async_utils import sleep_or_cancel
 from .context import Context, formatted_agent_mds, formatted_git_context, formatted_skills
 from .core.compaction import generate_summary, is_overflow, summary_max_tokens
 from .core.errors import format_error
@@ -222,6 +223,12 @@ class Agent:
 
                 if steer_event and steer_event.is_set():
                     stop_reason = StopReason.STEER
+                    break
+
+                cooldown = kon_config.agent.turn_cooldown_seconds
+                if cooldown > 0 and await sleep_or_cancel(cooldown, cancel_event):
+                    stop_reason = StopReason.INTERRUPTED
+                    yield InterruptedEvent(message="Interrupted by user")
                     break
 
                 # Check for context overflow after each turn.

--- a/src/kon/turn.py
+++ b/src/kon/turn.py
@@ -33,7 +33,7 @@ from enum import Enum, StrEnum, auto
 from pydantic import ValidationError
 
 from . import config as kon_config
-from .async_utils import OperationCancelledError, await_or_cancel
+from .async_utils import OperationCancelledError, await_or_cancel, sleep_or_cancel
 from .core.errors import format_error
 from .core.types import (
     AssistantMessage,
@@ -255,14 +255,6 @@ async def _await_approval(
         return None
 
 
-async def _sleep_or_cancel(delay: float, cancel_event: asyncio.Event | None) -> bool:
-    try:
-        await await_or_cancel(asyncio.create_task(asyncio.sleep(delay)), cancel_event)
-        return False
-    except OperationCancelledError:
-        return True
-
-
 class _ChunkOutcome(Enum):
     CHUNK = auto()
     EXHAUSTED = auto()
@@ -376,7 +368,7 @@ class _TurnRunner:
                         delay=delay,
                         error=format_error(e),
                     )
-                    if await _sleep_or_cancel(delay, self._cancel_event):
+                    if await sleep_or_cancel(delay, self._cancel_event):
                         for event in self._interrupted_turn_end():
                             yield event
                         return


### PR DESCRIPTION
Add configurable cooldown between agent turns, typical cooldown for well-known platform would be around `1.875`.