### PR TITLE
fix: Codex Responses Lite reasoning context and default_base_url routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- No changes yet.
+### Fixed
+
+- Fixed OpenAI Codex Responses Lite error `requires reasoning.context to be all_turns` by always sending `reasoning.context: "all_turns"` for GPT-5.6 Codex models, even when thinking is disabled.
 
 ## 0.4.2 - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed OpenAI Codex Responses Lite error `requires reasoning.context to be all_turns` by always sending `reasoning.context: "all_turns"` for GPT-5.6 Codex models, even when thinking is disabled.
+- Fixed `kon -m <model> --provider <provider>` routing requests for non-default providers to the config's `default_base_url` host (e.g. selecting `gpt-5.6-luna`/`openai-codex` while `default_base_url` points at DeepSeek caused 401 "api key invalid" errors). The config base URL override now applies only to the configured default provider.
 
 ## 0.4.2 - 2026-07-20
 

--- a/src/kon/headless.py
+++ b/src/kon/headless.py
@@ -83,7 +83,11 @@ async def run_headless(
             if provider is not None
             else (config.llm.default_provider if model is None else None)
         )
-        base = base_url or config.llm.default_base_url or None
+        # The config's default_base_url is applied inside the runtime for the
+        # default provider only; passing it here would misroute explicitly
+        # selected models from other providers (e.g. openai-codex) to the
+        # default provider's host.
+        base = base_url or None
         thinking = config.llm.default_thinking_level
         openai_auth = openai_compat_auth_mode or config.llm.auth.openai_compat
         anthropic_auth = anthropic_compat_auth_mode or config.llm.auth.anthropic_compat

--- a/src/kon/llm/providers/openai_codex_responses.py
+++ b/src/kon/llm/providers/openai_codex_responses.py
@@ -369,14 +369,23 @@ class OpenAICodexResponsesProvider(BaseProvider):
             body["tools"] = tool_payload
 
         effort = self.config.thinking_level
-        if effort and effort != "none":
-            if effort == "minimal":
-                effort = "low"
-            elif effort == "ultra":
-                effort = "max"
+        if effort == "minimal":
+            effort = "low"
+        elif effort == "ultra":
+            effort = "max"
+
+        if uses_responses_lite:
+            # Responses Lite requires `reasoning.context` to always be
+            # `all_turns`, even when thinking is disabled; otherwise the
+            # backend rejects the request. Mirror the Codex CLI fix that
+            # constructs the reasoning payload unconditionally for lite models.
+            body["reasoning"] = {
+                "effort": effort or "none",
+                "summary": "auto",
+                "context": "all_turns",
+            }
+        elif effort and effort != "none":
             body["reasoning"] = {"effort": effort, "summary": "auto"}
-            if uses_responses_lite:
-                body["reasoning"]["context"] = "all_turns"
 
         temp = temperature if temperature is not None else self.config.temperature
         if temp is not None:

--- a/src/kon/runtime.py
+++ b/src/kon/runtime.py
@@ -118,10 +118,27 @@ class ConversationRuntime:
         self, model: str, provider: str | None
     ) -> tuple[ApiType, str | None]:
         model_info = get_model(model, provider)
+
+        # `default_base_url` is an override for the configured default provider
+        # only. When a different provider is in effect (e.g. a catalog model
+        # whose provider differs from the default was selected), use that
+        # model's own endpoint instead of routing requests to the default
+        # provider's host.
+        effective_provider = provider
+        if effective_provider is None:
+            effective_provider = (
+                model_info.provider if model_info is not None else kon_config.llm.default_provider
+            )
+        config_override = (
+            kon_config.llm.default_base_url
+            if effective_provider == kon_config.llm.default_provider
+            else None
+        )
+
         if model_info:
-            return model_info.api, self.base_url or model_info.base_url
+            return model_info.api, self.base_url or config_override or model_info.base_url
         api_type = resolve_provider_api_type(provider)
-        return api_type, self.base_url or default_base_url_for_api(api_type)
+        return api_type, self.base_url or config_override or default_base_url_for_api(api_type)
 
     def _new_agent(
         self, provider: BaseProvider, session: Session, context: Context | None = None

--- a/src/kon/runtime.py
+++ b/src/kon/runtime.py
@@ -75,7 +75,9 @@ class ConversationRuntime:
         self.model = model
         self.model_provider = model_provider
         self.api_key = api_key
-        self.base_url = base_url
+        # Keep the explicit CLI override separate from resolved model/session URLs.
+        # It intentionally wins for every provider selected during this runtime.
+        self.explicit_base_url = base_url
         self.thinking_level = thinking_level
         self.tools = tools
         self.openai_compat_auth_mode: AuthMode = openai_compat_auth_mode
@@ -124,21 +126,27 @@ class ConversationRuntime:
         # whose provider differs from the default was selected), use that
         # model's own endpoint instead of routing requests to the default
         # provider's host.
-        effective_provider = provider
-        if effective_provider is None:
-            effective_provider = (
-                model_info.provider if model_info is not None else kon_config.llm.default_provider
-            )
+        effective_provider = (
+            model_info.provider
+            if model_info is not None
+            else provider or kon_config.llm.default_provider
+        )
         config_override = (
-            kon_config.llm.default_base_url
+            (kon_config.llm.default_base_url or None)
             if effective_provider == kon_config.llm.default_provider
             else None
         )
 
         if model_info:
-            return model_info.api, self.base_url or config_override or model_info.base_url
-        api_type = resolve_provider_api_type(provider)
-        return api_type, self.base_url or config_override or default_base_url_for_api(api_type)
+            return (
+                model_info.api,
+                self.explicit_base_url or config_override or model_info.base_url,
+            )
+        api_type = resolve_provider_api_type(effective_provider)
+        return (
+            api_type,
+            self.explicit_base_url or config_override or default_base_url_for_api(api_type),
+        )
 
     def _new_agent(
         self, provider: BaseProvider, session: Session, context: Context | None = None
@@ -161,7 +169,7 @@ class ConversationRuntime:
         self.context = context
         model = self.model
         model_provider = self.model_provider
-        base_url_override = self.base_url
+        session_base_url: str | None = None
         thinking_level = self.thinking_level
 
         if resume_session:
@@ -170,8 +178,6 @@ class ConversationRuntime:
                 model_info = session.model
                 if model_info:
                     model_provider, model, session_base_url = model_info
-                    if base_url_override is None and session_base_url:
-                        base_url_override = session_base_url
                 thinking_level = session.thinking_level
         elif continue_recent:
             session = Session.continue_recent(
@@ -185,12 +191,10 @@ class ConversationRuntime:
                 model_info = session.model
                 if model_info:
                     model_provider, model, session_base_url = model_info
-                    if base_url_override is None and session_base_url:
-                        base_url_override = session_base_url
                 thinking_level = session.thinking_level
 
-        self.base_url = base_url_override
-        api_type, effective_base_url = self._model_api_and_base_url(model, model_provider)
+        api_type, resolved_base_url = self._model_api_and_base_url(model, model_provider)
+        effective_base_url = self.explicit_base_url or session_base_url or resolved_base_url
         provider_config = self._provider_config(
             model=model,
             provider=model_provider,
@@ -261,9 +265,11 @@ class ConversationRuntime:
             if selected_model
             else (self.provider.name if self.provider else self.model_provider or "openai")
         )
-        model_base_url = selected_model.base_url if selected_model else None
-        if model_base_url is None and self.provider:
-            model_base_url = self.provider.config.base_url
+        model_base_url = self.provider.config.base_url if self.provider else None
+        if model_base_url is None and selected_model:
+            _, model_base_url = self._model_api_and_base_url(
+                selected_model.id, selected_model.provider
+            )
 
         session = Session.create(
             self.cwd,
@@ -296,27 +302,28 @@ class ConversationRuntime:
             if self.provider
             else self.model_provider
         )
+        target_api_type, target_base_url = self._model_api_and_base_url(model.id, model.provider)
         current_base_url = self.provider.config.base_url if self.provider else None
-        base_url_changed = (current_base_url or "").rstrip("/") != (model.base_url or "").rstrip(
+        base_url_changed = (current_base_url or "").rstrip("/") != (target_base_url or "").rstrip(
             "/"
         )
         provider_changed = current_provider != model.provider
         replacement_provider: BaseProvider | None = None
 
-        if model.api != current_api_type or provider_changed or base_url_changed:
+        if target_api_type != current_api_type or provider_changed or base_url_changed:
             provider_config = self._provider_config(
                 model=model.id,
                 provider=model.provider,
-                base_url=model.base_url,
+                base_url=target_base_url,
                 session_id=self.session.id if self.session else None,
             )
-            replacement_provider = create_provider(model.api, provider_config)
+            replacement_provider = create_provider(target_api_type, provider_config)
 
         if replacement_provider is not None:
             self.provider = replacement_provider
         elif self.provider:
             self.provider.config.model = model.id
-            self.provider.config.base_url = model.base_url
+            self.provider.config.base_url = target_base_url
             self.provider.config.max_tokens = get_max_tokens(model.id)
             self.provider.config.provider = model.provider
 
@@ -324,7 +331,7 @@ class ConversationRuntime:
         self.model_provider = model.provider
 
         if self.session:
-            self.session.set_model(model.provider, model.id, model.base_url)
+            self.session.set_model(model.provider, model.id, target_base_url)
         if self.agent and self.provider:
             self.agent.provider = self.provider
 
@@ -347,11 +354,10 @@ class ConversationRuntime:
         if model_info:
             model_provider, model, session_base_url = model_info
             restored_model = get_model(model, model_provider)
-            restored_base_url = session_base_url or (
-                restored_model.base_url if restored_model else None
-            )
 
             if restored_model:
+                _, resolved_base_url = self._model_api_and_base_url(model, model_provider)
+                restored_base_url = self.explicit_base_url or session_base_url or resolved_base_url
                 current_api_type = self._current_provider_api_type()
                 if provider is None or restored_model.api != current_api_type:
                     provider_config = self._provider_config(
@@ -363,15 +369,20 @@ class ConversationRuntime:
                     )
                     provider = create_provider(restored_model.api, provider_config)
             elif provider is None:
-                api_type = resolve_provider_api_type(model_provider)
+                api_type, resolved_base_url = self._model_api_and_base_url(model, model_provider)
+                restored_base_url = self.explicit_base_url or session_base_url or resolved_base_url
                 provider_config = self._provider_config(
                     model=model,
                     provider=model_provider,
-                    base_url=restored_base_url or default_base_url_for_api(api_type),
+                    base_url=restored_base_url,
                     thinking_level=thinking_level,
                     session_id=session.id,
                 )
                 provider = create_provider(api_type, provider_config)
+            else:
+                restored_base_url = (
+                    self.explicit_base_url or session_base_url or provider.config.base_url
+                )
         else:
             restored_base_url = None
 

--- a/src/kon/ui/app.py
+++ b/src/kon/ui/app.py
@@ -128,7 +128,11 @@ class Kon(
             else (config.llm.default_provider if model is None else None)
         )
         self._api_key = api_key
-        self._base_url = base_url or config.llm.default_base_url or None
+        # The config's default_base_url is applied inside the runtime for the
+        # default provider only; passing it here would misroute explicitly
+        # selected models from other providers (e.g. openai-codex) to the
+        # default provider's host.
+        self._base_url = base_url or None
         self._resume_session = resume_session
         self._continue_recent = continue_recent
         initial_thinking_level = thinking_level or config.llm.default_thinking_level

--- a/tests/llm/test_openai_codex_provider_errors.py
+++ b/tests/llm/test_openai_codex_provider_errors.py
@@ -175,6 +175,26 @@ def test_responses_lite_request_strips_image_detail():
     }
 
 
+def test_responses_lite_request_always_sends_reasoning_context_when_thinking_disabled():
+    provider = OpenAICodexResponsesProvider(
+        ProviderConfig(model="gpt-5.6-sol", provider="openai-codex", thinking_level="none")
+    )
+
+    body = provider._build_request_body([], None, None, None)
+
+    assert body["reasoning"] == {"effort": "none", "summary": "auto", "context": "all_turns"}
+
+
+def test_responses_lite_request_always_sends_reasoning_context_when_thinking_unset():
+    provider = OpenAICodexResponsesProvider(
+        ProviderConfig(model="gpt-5.6-sol", provider="openai-codex", thinking_level=None)
+    )
+
+    body = provider._build_request_body([], None, None, None)
+
+    assert body["reasoning"] == {"effort": "none", "summary": "auto", "context": "all_turns"}
+
+
 def test_responses_lite_headers_and_websocket_metadata():
     provider = OpenAICodexResponsesProvider(
         ProviderConfig(model="gpt-5.6-sol", provider="openai-codex")

--- a/tests/llm/test_openai_codex_provider_errors.py
+++ b/tests/llm/test_openai_codex_provider_errors.py
@@ -187,7 +187,7 @@ def test_responses_lite_request_always_sends_reasoning_context_when_thinking_dis
 
 def test_responses_lite_request_always_sends_reasoning_context_when_thinking_unset():
     provider = OpenAICodexResponsesProvider(
-        ProviderConfig(model="gpt-5.6-sol", provider="openai-codex", thinking_level=None)
+        ProviderConfig(model="gpt-5.6-sol", provider="openai-codex", thinking_level="")
     )
 
     body = provider._build_request_body([], None, None, None)

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -32,19 +32,21 @@ def testdefault_base_url_for_api_non_openai_completions():
 def _runtime(
     monkeypatch,
     *,
-    base_url=None,
-    default_provider="deepseek",
-    default_base_url="https://proxy.example.com/v1",
-):
+    base_url: str | None = None,
+    default_provider: str = "deepseek",
+    default_base_url: str = "https://proxy.example.com/v1",
+) -> ConversationRuntime:
     monkeypatch.setattr(kon_config.llm, "default_provider", default_provider)
     monkeypatch.setattr(kon_config.llm, "default_base_url", default_base_url)
-    rt = ConversationRuntime.__new__(ConversationRuntime)
-    rt.base_url = base_url
-    rt.api_key = None
-    rt.openai_compat_auth_mode = None
-    rt.anthropic_compat_auth_mode = None
-    rt.thinking_level = "none"
-    return rt
+    return ConversationRuntime(
+        cwd="/test/project",
+        model="deepseek-v4-flash",
+        model_provider=default_provider,
+        api_key=None,
+        base_url=base_url,
+        thinking_level="none",
+        tools=[],
+    )
 
 
 def test_non_default_provider_model_uses_its_own_base_url(monkeypatch):

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -1,6 +1,7 @@
+from kon import config as kon_config
 from kon.llm import resolve_provider_api_type
 from kon.llm.models import ApiType
-from kon.runtime import default_base_url_for_api
+from kon.runtime import ConversationRuntime, default_base_url_for_api
 
 
 def test_resolve_provider_api_type_known_provider():
@@ -26,3 +27,53 @@ def testdefault_base_url_for_api_openai_completions(monkeypatch):
 
 def testdefault_base_url_for_api_non_openai_completions():
     assert default_base_url_for_api(ApiType.ANTHROPIC_COPILOT) is None
+
+
+def _runtime(
+    monkeypatch,
+    *,
+    base_url=None,
+    default_provider="deepseek",
+    default_base_url="https://proxy.example.com/v1",
+):
+    monkeypatch.setattr(kon_config.llm, "default_provider", default_provider)
+    monkeypatch.setattr(kon_config.llm, "default_base_url", default_base_url)
+    rt = ConversationRuntime.__new__(ConversationRuntime)
+    rt.base_url = base_url
+    rt.api_key = None
+    rt.openai_compat_auth_mode = None
+    rt.anthropic_compat_auth_mode = None
+    rt.thinking_level = "none"
+    return rt
+
+
+def test_non_default_provider_model_uses_its_own_base_url(monkeypatch):
+    rt = _runtime(monkeypatch)
+
+    _, url = rt._model_api_and_base_url("gpt-5.6-luna", "openai-codex")
+
+    assert url == "https://chatgpt.com/backend-api"
+
+
+def test_model_without_explicit_provider_resolves_own_provider_base_url(monkeypatch):
+    rt = _runtime(monkeypatch)
+
+    _, url = rt._model_api_and_base_url("gpt-5.6-sol", None)
+
+    assert url == "https://chatgpt.com/backend-api"
+
+
+def test_default_provider_keeps_config_base_url_override(monkeypatch):
+    rt = _runtime(monkeypatch)
+
+    _, url = rt._model_api_and_base_url("deepseek-v4-flash", "deepseek")
+
+    assert url == "https://proxy.example.com/v1"
+
+
+def test_explicit_base_url_wins_over_model_default(monkeypatch):
+    rt = _runtime(monkeypatch, base_url="http://localhost:11434/v1")
+
+    _, url = rt._model_api_and_base_url("gpt-5.6-luna", "openai-codex")
+
+    assert url == "http://localhost:11434/v1"

--- a/tests/test_runtime_switch_model.py
+++ b/tests/test_runtime_switch_model.py
@@ -1,5 +1,6 @@
 import pytest
 
+from kon import config as kon_config
 from kon.core.types import Message, ToolDefinition
 from kon.llm.base import BaseProvider, LLMStream, ProviderConfig
 from kon.llm.models import ApiType, get_model
@@ -134,6 +135,73 @@ def test_switch_model_reuses_provider_when_openai_compatible_base_url_is_unchang
     assert provider.config.provider == "deepseek"
     assert provider.config.base_url == "https://api.deepseek.com"
     assert provider.config.model == "deepseek-v4-flash"
+
+
+def test_switch_model_uses_default_provider_base_url_override(monkeypatch):
+    monkeypatch.setattr(kon_config.llm, "default_provider", "deepseek")
+    monkeypatch.setattr(kon_config.llm, "default_base_url", "https://proxy.example.com/v1")
+    initial_provider = _FakeProvider(
+        ProviderConfig(
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api",
+            model="gpt-5.6-luna",
+        )
+    )
+    runtime = _runtime_with_provider(initial_provider)
+    target = get_model("deepseek-v4-flash", "deepseek")
+    assert target is not None
+
+    created_configs: list[ProviderConfig] = []
+
+    def fake_create_provider(api_type: ApiType, config: ProviderConfig) -> BaseProvider:
+        assert api_type == ApiType.OPENAI_COMPLETIONS
+        created_configs.append(config)
+        return _FakeProvider(config)
+
+    monkeypatch.setattr("kon.runtime.create_provider", fake_create_provider)
+
+    runtime.switch_model(target)
+
+    assert len(created_configs) == 1
+    assert runtime.provider is not None
+    assert runtime.provider.config.base_url == "https://proxy.example.com/v1"
+
+
+def test_switch_model_explicit_base_url_wins(monkeypatch):
+    monkeypatch.setattr(kon_config.llm, "default_provider", "deepseek")
+    monkeypatch.setattr(kon_config.llm, "default_base_url", "https://proxy.example.com/v1")
+    initial_provider = _FakeProvider(
+        ProviderConfig(
+            provider="deepseek", base_url="http://localhost:11434/v1", model="deepseek-v4-flash"
+        )
+    )
+    runtime = ConversationRuntime(
+        cwd="/test/project",
+        model=initial_provider.config.model,
+        model_provider=initial_provider.config.provider,
+        api_key="test-key",
+        base_url="http://localhost:11434/v1",
+        thinking_level="high",
+        tools=[],
+    )
+    runtime.provider = initial_provider
+    target = get_model("gpt-5.6-luna", "openai-codex")
+    assert target is not None
+
+    created_configs: list[ProviderConfig] = []
+
+    def fake_create_provider(api_type: ApiType, config: ProviderConfig) -> BaseProvider:
+        assert api_type == ApiType.OPENAI_CODEX_RESPONSES
+        created_configs.append(config)
+        return _FakeProvider(config)
+
+    monkeypatch.setattr("kon.runtime.create_provider", fake_create_provider)
+
+    runtime.switch_model(target)
+
+    assert len(created_configs) == 1
+    assert runtime.provider is not None
+    assert runtime.provider.config.base_url == "http://localhost:11434/v1"
 
 
 def test_switch_model_creates_provider_when_provider_is_none(monkeypatch):


### PR DESCRIPTION
## Summary

Two fixes for using the OpenAI Codex (ChatGPT subscription) models through kon:

### 1. Responses Lite `reasoning.context` error
GPT-5.6 Codex models (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) use the Responses **Lite** contract, which requires `reasoning.context: "all_turns"` on **every** request. Previously `reasoning` was only added when thinking was enabled, so with `default_thinking_level = "none"` the backend rejected requests with:

```
X-OpenAI-Internal-Codex-Responses-Lite requires `reasoning.context` to be `all_turns`.
```

Now the reasoning payload is always constructed for lite models (mirroring the upstream Codex CLI fix in openai/codex#33496):

```python
body["reasoning"] = {"effort": effort or "none", "summary": "auto", "context": "all_turns"}
```

### 2. `default_base_url` misrouting non-default providers
`kon -m gpt-5.6-luna --provider openai-codex` (and the TUI equivalent) applied the config's `default_base_url` override to *every* provider. When `default_base_url` points at a different provider (e.g. DeepSeek), Codex requests were sent to `https://api.deepseek.com/codex/responses`, producing a confusing 401:

```
Authentication Fails, Your api key: ****ghtw is invalid
```

The config `default_base_url` override now applies only to the configured **default** provider. Catalog models from other providers use their own endpoint; `--base-url` still wins explicitly.

## Changes

- `src/kon/llm/providers/openai_codex_responses.py` — always send `reasoning.context: "all_turns"` for Responses Lite models
- `src/kon/runtime.py` — scope `default_base_url` override to the default provider in `_model_api_and_base_url`
- `src/kon/headless.py`, `src/kon/ui/app.py` — stop pre-merging `default_base_url` into the runtime's base URL
- Tests + CHANGELOG for both fixes

## Test plan

- `kon -m gpt-5.6-luna --provider openai-codex -p "Reply with exactly: OK"` → responds `OK`
- Default DeepSeek provider path still works
- `ruff format`, `ruff check`, `pytest` all pass (763 tests)
